### PR TITLE
Simple fix for the x-platform challenges faced in using strerror_r.

### DIFF
--- a/src/db.cpp
+++ b/src/db.cpp
@@ -200,9 +200,8 @@ void DB::InitDB(MBConfig &config)
         // Check if the DB directory exist with proper permission
         if(access(mb_dir.c_str(), F_OK))
         {
-            char err_buf[32];
-            std::cerr << "database directory check for " + mb_dir + " failed: " +
-                         strerror_r(errno, err_buf, sizeof(err_buf)) << std::endl;
+            std::cerr << "database directory check for " + mb_dir + " failed errno: " +
+                          std::to_string(errno) << std::endl;
             status = MBError::NO_DB;
             return;
         }

--- a/src/free_list.cpp
+++ b/src/free_list.cpp
@@ -194,10 +194,8 @@ int FreeList::LoadListFromDisk()
             return MBError::SUCCESS;
         }
 
-        char err_buf[32];
-        Logger::Log(LOG_LEVEL_ERROR, "cannot access %s with full permission: ",
-                                 list_path.c_str(),
-                                 strerror_r(errno, err_buf, sizeof(err_buf)));
+        Logger::Log(LOG_LEVEL_ERROR, "cannot access %s with full permission: %d",
+                    list_path.c_str(), errno);
         return MBError::NOT_ALLOWED;
     }
 
@@ -230,9 +228,8 @@ int FreeList::LoadListFromDisk()
     // Remove the file
     if(unlink(list_path.c_str()) != 0)
     {
-        char err_buf[32];
-        Logger::Log(LOG_LEVEL_ERROR, "failed to delete file %s: %s ", list_path.c_str(),
-                    strerror_r(errno, err_buf, sizeof(err_buf)));
+        Logger::Log(LOG_LEVEL_ERROR, "failed to delete file %s: %d ",
+                    list_path.c_str(), errno);
         return MBError::WRITE_ERROR;
     }
 


### PR DESCRIPTION
Resolves #13 
- Printing errno instead of the strerror
- This facilitates easy build on Alpine Linux for containerization of mabain.
- TODO: provide a x-platform thread-safe strerror implementation