### PR TITLE
move writer lock check to an earlier state

### DIFF
--- a/src/db.cpp
+++ b/src/db.cpp
@@ -199,6 +199,33 @@ void DB::InitDB(MBConfig &config)
         mb_dir += "/";
     options = config.options;
 
+    if(config.options & CONSTS::ACCESS_MODE_WRITER)
+    { 
+        std::string lock_file = mb_dir + "_lock";
+        // internal check first
+        status = ResourcePool::getInstance().AddResourceByPath(lock_file, NULL);
+        if(status == MBError::SUCCESS)
+        {
+            if(!(config.options & CONSTS::MEMORY_ONLY_MODE))
+            {
+                // process check by file lock
+                writer_lock_fd = acquire_writer_lock(lock_file);
+                if(writer_lock_fd < 0)
+                    status = MBError::WRITER_EXIST;
+            }
+        }
+        else
+        {
+            status = MBError::WRITER_EXIST;
+        }
+        if(status == MBError::WRITER_EXIST)
+        {
+            Logger::Log(LOG_LEVEL_ERROR, "failed to initialize db: %s",
+                        MBError::get_error_str(status));
+            return;
+        }
+    }
+
     bool init_header = false;
     if(config.options & CONSTS::MEMORY_ONLY_MODE)
     {
@@ -272,29 +299,6 @@ void DB::InitDB(MBConfig &config)
 
     if(config.options & CONSTS::ACCESS_MODE_WRITER)
     {
-        std::string lock_file = mb_dir + "_lock";
-        // internal check first
-        status = ResourcePool::getInstance().AddResourceByPath(lock_file, NULL);
-        if(status == MBError::SUCCESS)
-        {
-            if(!(config.options & CONSTS::MEMORY_ONLY_MODE))
-            {
-                // process check by file lock
-                writer_lock_fd = acquire_writer_lock(lock_file);
-                if(writer_lock_fd < 0)
-                    status = MBError::WRITER_EXIST;
-            }
-        }
-        else
-        {
-            status = MBError::WRITER_EXIST;
-        }
-        if(status == MBError::WRITER_EXIST)
-        {
-            Logger::Log(LOG_LEVEL_ERROR, "failed to initialize db: %s",
-                        MBError::get_error_str(status));
-            return;
-        }
         if(config.options & CONSTS::ASYNC_WRITER_MODE)
             async_writer = new AsyncWriter(this);
     }

--- a/src/dict.cpp
+++ b/src/dict.cpp
@@ -66,8 +66,10 @@ Dict::Dict(const std::string &mbdir, bool init_header, int datasize,
     {
         if(block_sz_data != 0 && header->data_block_size != block_sz_data)
         {
+            std::cerr << "mabain data block size not match " << block_sz_data << ": "
+                      << header->data_block_size << std::endl;
+            PrintHeader(std::cout);
             Destroy();
-            std::cerr << "mabain data block size not match\n";
             throw (int) MBError::INVALID_SIZE;
         }
     }

--- a/src/dict_mem.cpp
+++ b/src/dict_mem.cpp
@@ -92,7 +92,8 @@ DictMem::DictMem(const std::string &mbdir, bool init_header, size_t memsize,
     {
         if(block_size != 0 && header->index_block_size != block_size)
         {
-            std::cerr << "mabain index block size not match\n";
+            std::cerr << "mabain index block size not match " << block_size << ": "
+                      << header->index_block_size << std::endl;
             Destroy();
             throw (int) MBError::INVALID_SIZE;
         }


### PR DESCRIPTION
Move writer lock check to an earlier stage to avoid possible confliction.