### PR TITLE
fix: undefined uint64_t on newer stdlib implementations

### DIFF
--- a/src/util/utils.cpp
+++ b/src/util/utils.cpp
@@ -21,6 +21,7 @@
 #include <errno.h>
 #include <fcntl.h>
 #include <iostream>
+#include <stdint.h>
 #include <sys/stat.h>
 #include <unistd.h>
 


### PR DESCRIPTION
Fix: Compilation error on newer Ubuntu versions

This commit addresses a compilation error encountered on newer Ubuntu distributions (e.g., Ubuntu 24.04).  The issue stemmed from the implicit declaration of `uint64_t`, which is no longer guaranteed by default in newer standard library implementations.

By explicitly including `<stdint.h>`, we ensure that `uint64_t` is properly defined, resolving the compilation error.  This change maintains backward compatibility with older systems where `uint64_t` might have been implicitly available.

The fix has been tested on both Ubuntu 20.04 and Ubuntu 24.04 and confirms successful compilation on both platforms.  No other functional changes are introduced by this commit.