### PR TITLE
Simplify jemalloc rebuild metadata

### DIFF
--- a/src/db.cpp
+++ b/src/db.cpp
@@ -571,6 +571,9 @@ bool DB::StartupRebuildRequested(const MBConfig& config, bool init_header) const
 
 int DB::PrepareStartupRebuild(const MBConfig& config, bool init_header)
 {
+    startup_rebuild_prepared = false;
+    startup_rebuild_reset_only = false;
+
     if (!StartupRebuildRequested(config, init_header))
         return MBError::SUCCESS;
 
@@ -584,51 +587,66 @@ int DB::PrepareStartupRebuild(const MBConfig& config, bool init_header)
     if (header == NULL)
         return MBError::NOT_INITIALIZED;
 
-    if (!header->RebuildInProgress()) {
-        header->ResetRebuildMetadata(REBUILD_STATE_PREP);
-        Logger::Log(LOG_LEVEL_INFO, "jemalloc startup rebuild entering PREP for %s",
+    if (header->rebuild_active != 0) {
+        startup_rebuild_reset_only = true;
+        Logger::Log(LOG_LEVEL_WARN,
+            "stale startup rebuild marker detected for %s; next startup will clear DB to fresh state",
             mb_dir.c_str());
-    } else {
-        Logger::Log(LOG_LEVEL_INFO, "jemalloc startup rebuild resuming state %u for %s",
-            header->rebuild_state, mb_dir.c_str());
+        return MBError::SUCCESS;
     }
 
+    if (header->excep_updating_status != EXCEP_STATUS_NONE) {
+        startup_rebuild_reset_only = true;
+        Logger::Log(LOG_LEVEL_WARN,
+            "jemalloc startup found exception update status %d for %s; next startup will clear DB to fresh state without recovery",
+            header->excep_updating_status, mb_dir.c_str());
+        return MBError::SUCCESS;
+    }
+
+    startup_rebuild_prepared = true;
+    Logger::Log(LOG_LEVEL_INFO, "jemalloc startup rebuild requested for %s",
+        mb_dir.c_str());
     return MBError::SUCCESS;
 }
 
 bool DB::StartupRebuildMetadataReady() const
 {
     IndexHeader* header = dict == NULL ? NULL : dict->GetHeaderPtr();
-    if (header == NULL)
-        return false;
-    if (header->rebuild_state == REBUILD_STATE_PREP)
-        return false;
-    if (header->rebuild_state != REBUILD_STATE_COPY
-        && header->rebuild_state != REBUILD_STATE_CUTOVER)
-        return false;
-    if (header->rebuild_index_alloc_end == 0 || header->rebuild_data_alloc_end == 0
-        || header->rebuild_index_source_end == 0 || header->rebuild_data_source_end == 0)
-        return false;
-    if (header->rebuild_index_source_end < header->rebuild_index_alloc_end
-        || header->rebuild_data_source_end < header->rebuild_data_alloc_end)
-        return false;
-    return true;
+    return header != NULL && header->rebuild_active != 0;
 }
 
 bool DB::StartupRebuildComplete() const
 {
     IndexHeader* header = dict == NULL ? NULL : dict->GetHeaderPtr();
-    if (header == NULL || !StartupRebuildMetadataReady())
-        return false;
-
-    return header->rebuild_index_block_cursor >= header->rebuild_index_source_end
-        && header->rebuild_data_block_cursor >= header->rebuild_data_source_end
-        && header->reusable_index_block_count == 0
-        && header->reusable_data_block_count == 0;
+    return header != NULL && header->rebuild_active == 0;
 }
 
 int DB::RunStartupRebuild()
 {
+    auto reset_to_fresh_state = [&]() -> int {
+        startup_rebuild_prepared = false;
+        startup_rebuild_reset_only = false;
+        if (dict == NULL)
+            return MBError::NOT_INITIALIZED;
+        int rval = dict->RemoveAll();
+        if (rval != MBError::SUCCESS)
+            return rval;
+        IndexHeader* reset_header = dict->GetHeaderPtr();
+        if (reset_header != NULL) {
+            reset_header->ClearRebuildMetadata();
+            reset_header->ResetReaderEpochState();
+            reset_header->pending_index_buff_size = 0;
+            reset_header->pending_data_buff_size = 0;
+            reset_header->jemalloc_index_free_start = 0;
+            reset_header->jemalloc_data_free_start = 0;
+            reset_header->excep_updating_status = EXCEP_STATUS_NONE;
+            reset_header->excep_offset = 0;
+            reset_header->excep_lf_offset = 0;
+            memset(reset_header->excep_buff, 0, sizeof(reset_header->excep_buff));
+        }
+        return MBError::SUCCESS;
+    };
+
     try {
         if (!(options & CONSTS::ACCESS_MODE_WRITER)
             || !(options & CONSTS::OPTION_JEMALLOC))
@@ -638,54 +656,57 @@ int DB::RunStartupRebuild()
         IndexHeader* header = dict->GetHeaderPtr();
         if (header == NULL)
             return MBError::NOT_INITIALIZED;
-        if (!header->RebuildInProgress())
+
+        if (startup_rebuild_reset_only)
+            return reset_to_fresh_state();
+        if (!startup_rebuild_prepared)
             return MBError::SUCCESS;
 
-        if (header->excep_updating_status != EXCEP_STATUS_NONE) {
-            int rval = dict->ExceptionRecovery();
-            if (rval != MBError::SUCCESS)
-                return rval;
-            header->excep_lf_offset = 0;
-            header->excep_offset = 0;
-        }
+        header->SetRebuildActive();
+        header->ResetReaderEpochState();
 
         ResourceCollection rc(*this);
-        if (header->rebuild_state == REBUILD_STATE_PREP) {
-            int rval = rc.StartupShrink();
-            if (rval != MBError::SUCCESS)
-                return rval;
-        } else if (!StartupRebuildMetadataReady()) {
-            Logger::Log(LOG_LEVEL_ERROR,
-                "startup rebuild metadata incomplete for resumed state %u", header->rebuild_state);
-            return MBError::INVALID_SIZE;
+        rc.ResetStartupRebuildState(REBUILD_STATE_PREP);
+        int rval = rc.StartupShrink();
+        if (rval != MBError::SUCCESS) {
+            Logger::Log(LOG_LEVEL_WARN, "startup rebuild shrink failed for %s: %s",
+                mb_dir.c_str(), MBError::get_error_str(rval));
+            return reset_to_fresh_state();
         }
 
         uint32_t stalled_retry_count = 0;
         const uint32_t startup_rebuild_stall_retry_limit = 60000;
-        while (!StartupRebuildComplete()) {
-            const size_t index_cursor = header->rebuild_index_block_cursor;
-            const size_t data_cursor = header->rebuild_data_block_cursor;
-            const uint32_t index_reusable = header->reusable_index_block_count;
-            const uint32_t data_reusable = header->reusable_data_block_count;
+        while (!rc.StartupRebuildComplete()) {
+            size_t index_cursor = 0;
+            size_t data_cursor = 0;
+            uint32_t index_reusable = 0;
+            uint32_t data_reusable = 0;
+            rc.GetStartupRebuildProgress(index_cursor, data_cursor,
+                index_reusable, data_reusable);
 
-            int rval = rc.StartupEvacuate();
-            if (rval != MBError::SUCCESS)
-                return rval;
-            if (!StartupRebuildComplete()
-                && index_cursor == header->rebuild_index_block_cursor
-                && data_cursor == header->rebuild_data_block_cursor
-                && index_reusable == header->reusable_index_block_count
-                && data_reusable == header->reusable_data_block_count) {
+            rval = rc.StartupEvacuate();
+            if (rval != MBError::SUCCESS) {
+                Logger::Log(LOG_LEVEL_WARN, "startup rebuild evacuate failed for %s: %s",
+                    mb_dir.c_str(), MBError::get_error_str(rval));
+                return reset_to_fresh_state();
+            }
+
+            size_t next_index_cursor = 0;
+            size_t next_data_cursor = 0;
+            uint32_t next_index_reusable = 0;
+            uint32_t next_data_reusable = 0;
+            rc.GetStartupRebuildProgress(next_index_cursor, next_data_cursor,
+                next_index_reusable, next_data_reusable);
+            if (!rc.StartupRebuildComplete()
+                && index_cursor == next_index_cursor
+                && data_cursor == next_data_cursor
+                && index_reusable == next_index_reusable
+                && data_reusable == next_data_reusable) {
                 if (++stalled_retry_count > startup_rebuild_stall_retry_limit) {
-                    Logger::Log(LOG_LEVEL_ERROR,
-                        "startup rebuild timed out waiting for progress index_cursor=%llu/%llu data_cursor=%llu/%llu reusable=%u/%u",
-                        static_cast<unsigned long long>(header->rebuild_index_block_cursor),
-                        static_cast<unsigned long long>(header->rebuild_index_source_end),
-                        static_cast<unsigned long long>(header->rebuild_data_block_cursor),
-                        static_cast<unsigned long long>(header->rebuild_data_source_end),
-                        header->reusable_index_block_count,
-                        header->reusable_data_block_count);
-                    return MBError::TIMEOUT;
+                    Logger::Log(LOG_LEVEL_WARN,
+                        "startup rebuild timed out waiting for progress for %s; clearing DB to fresh state",
+                        mb_dir.c_str());
+                    return reset_to_fresh_state();
                 }
                 usleep(1000);
             } else {
@@ -696,18 +717,21 @@ int DB::RunStartupRebuild()
         header->pending_index_buff_size = 0;
         header->pending_data_buff_size = 0;
         header->reader_epoch_tracking_active.store(0, MEMORY_ORDER_WRITER);
-        header->jemalloc_index_free_start = header->rebuild_index_alloc_end;
-        header->jemalloc_data_free_start = header->rebuild_data_alloc_end;
+        header->jemalloc_index_free_start = rc.GetStartupRebuildState().rebuild_index_alloc_end;
+        header->jemalloc_data_free_start = rc.GetStartupRebuildState().rebuild_data_alloc_end;
         header->ClearRebuildMetadata();
+        startup_rebuild_prepared = false;
+        startup_rebuild_reset_only = false;
         Logger::Log(LOG_LEVEL_INFO, "jemalloc startup rebuild completed for %s", mb_dir.c_str());
         return MBError::SUCCESS;
     } catch (int err) {
-        Logger::Log(LOG_LEVEL_ERROR, "startup rebuild failed with exception: %s",
-            MBError::get_error_str(err));
-        return err;
+        Logger::Log(LOG_LEVEL_WARN, "startup rebuild failed with exception for %s: %s; clearing DB to fresh state",
+            mb_dir.c_str(), MBError::get_error_str(err));
+        return reset_to_fresh_state();
     } catch (...) {
-        Logger::Log(LOG_LEVEL_ERROR, "startup rebuild failed with unknown exception");
-        return MBError::UNKNOWN_ERROR;
+        Logger::Log(LOG_LEVEL_WARN, "startup rebuild failed with unknown exception for %s; clearing DB to fresh state",
+            mb_dir.c_str());
+        return reset_to_fresh_state();
     }
 }
 

--- a/src/db.h
+++ b/src/db.h
@@ -258,6 +258,8 @@ private:
     uint64_t process_start_time;
     mutable uint64_t reader_guard_fast_slot_count;
     mutable uint64_t reader_guard_barrier_fallback_count;
+    bool startup_rebuild_prepared = false;
+    bool startup_rebuild_reset_only = false;
 
     // db lock
     MBLock lock;

--- a/src/drm_base.cpp
+++ b/src/drm_base.cpp
@@ -33,24 +33,6 @@ bool HeaderVersionMatchesCurrent(const uint16_t hdr_ver[4])
         && hdr_ver[2] == version[2];
 }
 
-const char* RebuildStateToString(int state)
-{
-    switch (state) {
-    case REBUILD_STATE_NORMAL:
-        return "NORMAL";
-    case REBUILD_STATE_PREP:
-        return "REBUILD_PREP";
-    case REBUILD_STATE_COPY:
-        return "REBUILD_COPY";
-    case REBUILD_STATE_CUTOVER:
-        return "REBUILD_CUTOVER";
-    case REBUILD_STATE_POST:
-        return "REBUILD_POST";
-    default:
-        return "UNKNOWN";
-    }
-}
-
 } // namespace
 
 void DRMBase::ReadHeaderVersion(const std::string& header_path, uint16_t ver[4])
@@ -158,23 +140,10 @@ void DRMBase::PrintHeader(std::ostream& out_stream) const
     out_stream << "max data offset before rc: " << header->rc_m_data_off_pre << std::endl;
     out_stream << "rc root offset: " << header->rc_root_offset << std::endl;
     out_stream << "rc count: " << header->rc_count << std::endl;
-    out_stream << "rebuild state: " << RebuildStateToString(header->rebuild_state)
-               << " (" << header->rebuild_state << ")" << std::endl;
-    out_stream << "rebuild root offset: " << header->rebuild_root_offset << std::endl;
-    out_stream << "rebuild index alloc start: " << header->rebuild_index_alloc_start << std::endl;
-    out_stream << "rebuild data alloc start: " << header->rebuild_data_alloc_start << std::endl;
-    out_stream << "rebuild cutover index: " << header->rebuild_cutover_index << std::endl;
-    out_stream << "rebuild index alloc end: " << header->rebuild_index_alloc_end << std::endl;
-    out_stream << "rebuild data alloc end: " << header->rebuild_data_alloc_end << std::endl;
-    out_stream << "rebuild index source end: " << header->rebuild_index_source_end << std::endl;
-    out_stream << "rebuild data source end: " << header->rebuild_data_source_end << std::endl;
-    out_stream << "rebuild index block cursor: " << header->rebuild_index_block_cursor << std::endl;
-    out_stream << "rebuild data block cursor: " << header->rebuild_data_block_cursor << std::endl;
+    out_stream << "rebuild active: " << header->rebuild_active << std::endl;
     out_stream << "reader epoch tracking active: " << header->reader_epoch_tracking_active << std::endl;
     out_stream << "reader epoch slot count: " << header->reader_epoch_slot_count << std::endl;
     out_stream << "reader epoch: " << header->reader_epoch << std::endl;
-    out_stream << "reusable index block count: " << header->reusable_index_block_count << std::endl;
-    out_stream << "reusable data block count: " << header->reusable_data_block_count << std::endl;
     out_stream << "shared memory queue size: " << header->async_queue_size << std::endl;
     out_stream << "shared memory queue index: " << header->queue_index << std::endl;
     out_stream << "shared memory writer index: " << header->writer_index << std::endl;

--- a/src/drm_base.h
+++ b/src/drm_base.h
@@ -189,18 +189,10 @@ typedef struct _IndexHeader {
     std::atomic<size_t> rc_root_offset;
     int64_t rc_count;
 
-    // startup rebuild metadata (jemalloc keep-db path)
-    int rebuild_state;
-    size_t rebuild_root_offset;
-    size_t rebuild_index_alloc_start;
-    size_t rebuild_data_alloc_start;
-    int rebuild_cutover_index;
-    size_t rebuild_index_alloc_end;
-    size_t rebuild_data_alloc_end;
-    size_t rebuild_index_source_end;
-    size_t rebuild_data_source_end;
-    size_t rebuild_index_block_cursor;
-    size_t rebuild_data_block_cursor;
+    // Best-effort startup rebuild marker for jemalloc keep-db mode.
+    // If set on open, the previous rebuild did not finish and the DB is reset
+    // to a fresh state instead of attempting resume.
+    uint32_t rebuild_active;
 
     // Offsets below these boundaries were compacted into place by startup rebuild
     // and must not be returned to the current jemalloc arena via dallocx().
@@ -212,12 +204,6 @@ typedef struct _IndexHeader {
     uint32_t reader_epoch_slot_count;
     std::atomic<uint64_t> reader_epoch;
     ReaderEpochSlot reader_epoch_slot[MB_MAX_READER_EPOCH_SLOT];
-
-    // Quarantined whole blocks that can later become reusable.
-    uint32_t reusable_index_block_count;
-    uint32_t reusable_data_block_count;
-    ReusableBlockEntry reusable_index_block[MB_MAX_REUSABLE_BLOCKS];
-    ReusableBlockEntry reusable_data_block[MB_MAX_REUSABLE_BLOCKS];
 
     // multi-process async queue
     int async_queue_size;
@@ -233,30 +219,14 @@ typedef struct _IndexHeader {
     uint32_t pfx_cap3;      // number of slots in 3-byte table
     uint32_t pfx_cap4;      // number of slots in 4-byte table
 
-    void ResetRebuildMetadata(int state)
+    void SetRebuildActive()
     {
-        rebuild_state = state;
-        rebuild_root_offset = 0;
-        rebuild_index_alloc_start = 0;
-        rebuild_data_alloc_start = 0;
-        rebuild_cutover_index = 0;
-        rebuild_index_alloc_end = 0;
-        rebuild_data_alloc_end = 0;
-        rebuild_index_source_end = 0;
-        rebuild_data_source_end = 0;
-        rebuild_index_block_cursor = 0;
-        rebuild_data_block_cursor = 0;
-        reusable_index_block_count = 0;
-        reusable_data_block_count = 0;
-        for (int i = 0; i < MB_MAX_REUSABLE_BLOCKS; i++) {
-            reusable_index_block[i].Clear();
-            reusable_data_block[i].Clear();
-        }
+        rebuild_active = 1u;
     }
 
     void ClearRebuildMetadata()
     {
-        ResetRebuildMetadata(REBUILD_STATE_NORMAL);
+        rebuild_active = 0;
     }
 
     void ResetReaderEpochState()
@@ -270,7 +240,7 @@ typedef struct _IndexHeader {
 
     bool RebuildInProgress() const
     {
-        return rebuild_state != REBUILD_STATE_NORMAL;
+        return rebuild_active != 0;
     }
 } IndexHeader;
 

--- a/src/mb_rc.cpp
+++ b/src/mb_rc.cpp
@@ -88,6 +88,7 @@ ResourceCollection::ResourceCollection(const DB& db, int rct)
     evacuate_data_block_start = 0;
     evacuate_data_block_end = 0;
     async_writer_ptr = NULL;
+    startup_rebuild_.Clear();
 }
 
 ResourceCollection::~ResourceCollection()
@@ -224,11 +225,11 @@ int ResourceCollection::StartupShrink()
         return MBError::NOT_ALLOWED;
     if (header == NULL)
         return MBError::NOT_INITIALIZED;
-    if (header->rebuild_state != REBUILD_STATE_PREP
-        && header->rebuild_state != REBUILD_STATE_COPY) {
+    if (startup_rebuild_.rebuild_state != REBUILD_STATE_PREP
+        && startup_rebuild_.rebuild_state != REBUILD_STATE_COPY) {
         Logger::Log(LOG_LEVEL_WARN,
             "startup shrink requires PREP/COPY state, current state=%d",
-            header->rebuild_state);
+            startup_rebuild_.rebuild_state);
         return MBError::NOT_ALLOWED;
     }
 
@@ -248,11 +249,9 @@ int ResourceCollection::StartupShrink()
         return MBError::INVALID_SIZE;
     }
 
-    header->ResetRebuildMetadata(REBUILD_STATE_COPY);
-    header->rebuild_index_alloc_start = index_tail;
-    header->rebuild_data_alloc_start = data_tail;
-    header->rebuild_index_alloc_end = index_tail;
-    header->rebuild_data_alloc_end = data_tail;
+    startup_rebuild_.Reset(REBUILD_STATE_COPY);
+    startup_rebuild_.rebuild_index_alloc_end = index_tail;
+    startup_rebuild_.rebuild_data_alloc_end = data_tail;
 
     // In jemalloc mode, normal live offsets are not reliable reopen tails.
     // Reorder must use a non-overlapping workspace beyond the existing block end.
@@ -278,18 +277,16 @@ int ResourceCollection::StartupShrink()
     CollectBuffers();
     Finish();
 
-    header->rebuild_index_alloc_start = header->m_index_offset;
-    header->rebuild_index_source_end = std::max(index_block_end, header->m_index_offset);
-    header->rebuild_data_alloc_start = header->m_data_offset;
-    header->rebuild_data_source_end = std::max(data_block_end, header->m_data_offset);
-    header->rebuild_index_alloc_end = header->m_index_offset;
-    header->rebuild_data_alloc_end = header->m_data_offset;
+    startup_rebuild_.rebuild_index_source_end = std::max(index_block_end, header->m_index_offset);
+    startup_rebuild_.rebuild_data_source_end = std::max(data_block_end, header->m_data_offset);
+    startup_rebuild_.rebuild_index_alloc_end = header->m_index_offset;
+    startup_rebuild_.rebuild_data_alloc_end = header->m_data_offset;
     Logger::Log(LOG_LEVEL_INFO,
         "startup shrink completed compacted boundaries index=%llu data=%llu with source block ends index=%llu data=%llu",
-        static_cast<unsigned long long>(header->rebuild_index_alloc_end),
-        static_cast<unsigned long long>(header->rebuild_data_alloc_end),
-        static_cast<unsigned long long>(header->rebuild_index_source_end),
-        static_cast<unsigned long long>(header->rebuild_data_source_end));
+        static_cast<unsigned long long>(startup_rebuild_.rebuild_index_alloc_end),
+        static_cast<unsigned long long>(startup_rebuild_.rebuild_data_alloc_end),
+        static_cast<unsigned long long>(startup_rebuild_.rebuild_index_source_end),
+        static_cast<unsigned long long>(startup_rebuild_.rebuild_data_source_end));
     return MBError::SUCCESS;
 }
 
@@ -303,18 +300,18 @@ int ResourceCollection::StartupEvacuate()
         return MBError::NOT_ALLOWED;
     if (header == NULL)
         return MBError::NOT_INITIALIZED;
-    if (header->rebuild_state != REBUILD_STATE_COPY
-        && header->rebuild_state != REBUILD_STATE_CUTOVER) {
+    if (startup_rebuild_.rebuild_state != REBUILD_STATE_COPY
+        && startup_rebuild_.rebuild_state != REBUILD_STATE_CUTOVER) {
         Logger::Log(LOG_LEVEL_WARN,
             "startup evacuate requires COPY/CUTOVER state, current state=%d",
-            header->rebuild_state);
+            startup_rebuild_.rebuild_state);
         return MBError::NOT_ALLOWED;
     }
 
-    const size_t index_boundary = header->rebuild_index_alloc_end;
-    const size_t data_boundary = header->rebuild_data_alloc_end;
-    const size_t index_source_end = header->rebuild_index_source_end;
-    const size_t data_source_end = header->rebuild_data_source_end;
+    const size_t index_boundary = startup_rebuild_.rebuild_index_alloc_end;
+    const size_t data_boundary = startup_rebuild_.rebuild_data_alloc_end;
+    const size_t index_source_end = startup_rebuild_.rebuild_index_source_end;
+    const size_t data_source_end = startup_rebuild_.rebuild_data_source_end;
     if (index_boundary == 0 || data_boundary == 0
         || index_source_end == 0 || data_source_end == 0)
         return MBError::NOT_INITIALIZED;
@@ -329,7 +326,7 @@ int ResourceCollection::StartupEvacuate()
         return MBError::INVALID_SIZE;
 
     int rval = MBError::SUCCESS;
-    if (header->rebuild_state == REBUILD_STATE_COPY) {
+    if (startup_rebuild_.rebuild_state == REBUILD_STATE_COPY) {
         rval = dmm->ResetJemalloc();
         if (rval != MBError::SUCCESS)
             return rval;
@@ -343,63 +340,61 @@ int ResourceCollection::StartupEvacuate()
         if (rval != MBError::SUCCESS)
             return rval;
 
-        header->rebuild_index_alloc_start = index_source_start;
-        header->rebuild_data_alloc_start = data_source_start;
-        header->rebuild_index_block_cursor = index_source_start;
-        header->rebuild_data_block_cursor = data_source_start;
-        header->reusable_index_block_count = 0;
-        header->reusable_data_block_count = 0;
+        startup_rebuild_.rebuild_index_block_cursor = index_source_start;
+        startup_rebuild_.rebuild_data_block_cursor = data_source_start;
+        startup_rebuild_.reusable_index_block_count = 0;
+        startup_rebuild_.reusable_data_block_count = 0;
         for (int i = 0; i < MB_MAX_REUSABLE_BLOCKS; i++) {
-            header->reusable_index_block[i].Clear();
-            header->reusable_data_block[i].Clear();
+            startup_rebuild_.reusable_index_block[i].Clear();
+            startup_rebuild_.reusable_data_block[i].Clear();
         }
         header->reader_epoch.store(1, MEMORY_ORDER_WRITER);
-        header->rebuild_state = REBUILD_STATE_CUTOVER;
+        startup_rebuild_.rebuild_state = REBUILD_STATE_CUTOVER;
     }
 
     const bool tracking_needed_before =
-        (header->rebuild_index_block_cursor < header->rebuild_index_source_end)
-        || (header->rebuild_data_block_cursor < header->rebuild_data_source_end)
-        || HasPendingReusableBlocks(header->reusable_index_block,
-            header->reusable_index_block_count)
-        || HasPendingReusableBlocks(header->reusable_data_block,
-            header->reusable_data_block_count);
+        (startup_rebuild_.rebuild_index_block_cursor < startup_rebuild_.rebuild_index_source_end)
+        || (startup_rebuild_.rebuild_data_block_cursor < startup_rebuild_.rebuild_data_source_end)
+        || HasPendingReusableBlocks(startup_rebuild_.reusable_index_block,
+            startup_rebuild_.reusable_index_block_count)
+        || HasPendingReusableBlocks(startup_rebuild_.reusable_data_block,
+            startup_rebuild_.reusable_data_block_count);
     header->reader_epoch_tracking_active.store(tracking_needed_before ? 1 : 0, MEMORY_ORDER_WRITER);
 
     const bool has_quarantined_blocks =
-        HasPendingReusableBlocks(header->reusable_index_block,
-            header->reusable_index_block_count)
-        || HasPendingReusableBlocks(header->reusable_data_block,
-            header->reusable_data_block_count);
+        HasPendingReusableBlocks(startup_rebuild_.reusable_index_block,
+            startup_rebuild_.reusable_index_block_count)
+        || HasPendingReusableBlocks(startup_rebuild_.reusable_data_block,
+            startup_rebuild_.reusable_data_block_count);
     if (has_quarantined_blocks) {
         rval = db_ref.AcquireRebuildBarrierExclusive();
         if (rval != MBError::SUCCESS)
             return rval;
 
-        rval = ReleaseReusableBlocks(header->reusable_index_block,
-            header->reusable_index_block_count);
+        rval = ReleaseReusableBlocks(startup_rebuild_.reusable_index_block,
+            startup_rebuild_.reusable_index_block_count);
         if (rval == MBError::SUCCESS) {
-            rval = ReleaseReusableBlocks(header->reusable_data_block,
-                header->reusable_data_block_count);
+            rval = ReleaseReusableBlocks(startup_rebuild_.reusable_data_block,
+                startup_rebuild_.reusable_data_block_count);
         }
         if (rval == MBError::SUCCESS) {
-            rval = DrainReusableBlocks(header->reusable_index_block,
-                header->reusable_index_block_count, dmm);
+            rval = DrainReusableBlocks(startup_rebuild_.reusable_index_block,
+                startup_rebuild_.reusable_index_block_count, dmm);
         }
         if (rval == MBError::SUCCESS) {
-            rval = DrainReusableBlocks(header->reusable_data_block,
-                header->reusable_data_block_count, dict);
+            rval = DrainReusableBlocks(startup_rebuild_.reusable_data_block,
+                startup_rebuild_.reusable_data_block_count, dict);
         }
         db_ref.ReleaseRebuildBarrierExclusive();
         if (rval != MBError::SUCCESS)
             return rval;
     } else {
-        rval = DrainReusableBlocks(header->reusable_index_block,
-            header->reusable_index_block_count, dmm);
+        rval = DrainReusableBlocks(startup_rebuild_.reusable_index_block,
+            startup_rebuild_.reusable_index_block_count, dmm);
         if (rval != MBError::SUCCESS)
             return rval;
-        rval = DrainReusableBlocks(header->reusable_data_block,
-            header->reusable_data_block_count, dict);
+        rval = DrainReusableBlocks(startup_rebuild_.reusable_data_block,
+            startup_rebuild_.reusable_data_block_count, dict);
         if (rval != MBError::SUCCESS)
             return rval;
     }
@@ -412,15 +407,42 @@ int ResourceCollection::StartupEvacuate()
         return rval;
 
     const bool tracking_needed =
-        (header->rebuild_index_block_cursor < header->rebuild_index_source_end)
-        || (header->rebuild_data_block_cursor < header->rebuild_data_source_end)
-        || HasPendingReusableBlocks(header->reusable_index_block,
-            header->reusable_index_block_count)
-        || HasPendingReusableBlocks(header->reusable_data_block,
-            header->reusable_data_block_count);
+        (startup_rebuild_.rebuild_index_block_cursor < startup_rebuild_.rebuild_index_source_end)
+        || (startup_rebuild_.rebuild_data_block_cursor < startup_rebuild_.rebuild_data_source_end)
+        || HasPendingReusableBlocks(startup_rebuild_.reusable_index_block,
+            startup_rebuild_.reusable_index_block_count)
+        || HasPendingReusableBlocks(startup_rebuild_.reusable_data_block,
+            startup_rebuild_.reusable_data_block_count);
     header->reader_epoch_tracking_active.store(tracking_needed ? 1 : 0, MEMORY_ORDER_WRITER);
 
     return MBError::SUCCESS;
+}
+
+void ResourceCollection::ResetStartupRebuildState(int state)
+{
+    startup_rebuild_.Reset(state);
+}
+
+bool ResourceCollection::StartupRebuildComplete() const
+{
+    return startup_rebuild_.rebuild_index_block_cursor >= startup_rebuild_.rebuild_index_source_end
+        && startup_rebuild_.rebuild_data_block_cursor >= startup_rebuild_.rebuild_data_source_end
+        && startup_rebuild_.reusable_index_block_count == 0
+        && startup_rebuild_.reusable_data_block_count == 0;
+}
+
+void ResourceCollection::GetStartupRebuildProgress(size_t& index_cursor, size_t& data_cursor,
+    uint32_t& index_reusable, uint32_t& data_reusable) const
+{
+    index_cursor = startup_rebuild_.rebuild_index_block_cursor;
+    data_cursor = startup_rebuild_.rebuild_data_block_cursor;
+    index_reusable = startup_rebuild_.reusable_index_block_count;
+    data_reusable = startup_rebuild_.reusable_data_block_count;
+}
+
+const StartupRebuildRuntimeState& ResourceCollection::GetStartupRebuildState() const
+{
+    return startup_rebuild_;
 }
 
 bool ResourceCollection::MoveIndexBufferEvacuate(size_t& offset_src, int size)
@@ -565,25 +587,25 @@ int ResourceCollection::DrainReusableBlocks(ReusableBlockEntry* entries, uint32_
 
 int ResourceCollection::EvacuateOneIndexBlock()
 {
-    if (header->rebuild_index_block_cursor >= header->rebuild_index_source_end)
+    if (startup_rebuild_.rebuild_index_block_cursor >= startup_rebuild_.rebuild_index_source_end)
         return MBError::RC_SKIPPED;
 
-    evacuate_index_block_start = header->rebuild_index_block_cursor;
+    evacuate_index_block_start = startup_rebuild_.rebuild_index_block_cursor;
     evacuate_index_block_end = evacuate_index_block_start + header->index_block_size;
-    if (evacuate_index_block_end > header->rebuild_index_source_end)
+    if (evacuate_index_block_end > startup_rebuild_.rebuild_index_source_end)
         return MBError::RC_SKIPPED;
 
     TraverseDB(RESOURCE_COLLECTION_PHASE_EVACUATE_INDEX);
 
     uint64_t retire_epoch = header->reader_epoch.fetch_add(1, MEMORY_ORDER_WRITER);
-    int rval = QueueReusableBlock(header->reusable_index_block,
-        header->reusable_index_block_count,
+    int rval = QueueReusableBlock(startup_rebuild_.reusable_index_block,
+        startup_rebuild_.reusable_index_block_count,
         evacuate_index_block_start / header->index_block_size,
         retire_epoch);
     if (rval != MBError::SUCCESS)
         return rval;
 
-    header->rebuild_index_block_cursor = evacuate_index_block_end;
+    startup_rebuild_.rebuild_index_block_cursor = evacuate_index_block_end;
     evacuate_index_block_start = 0;
     evacuate_index_block_end = 0;
     return MBError::SUCCESS;
@@ -591,25 +613,25 @@ int ResourceCollection::EvacuateOneIndexBlock()
 
 int ResourceCollection::EvacuateOneDataBlock()
 {
-    if (header->rebuild_data_block_cursor >= header->rebuild_data_source_end)
+    if (startup_rebuild_.rebuild_data_block_cursor >= startup_rebuild_.rebuild_data_source_end)
         return MBError::RC_SKIPPED;
 
-    evacuate_data_block_start = header->rebuild_data_block_cursor;
+    evacuate_data_block_start = startup_rebuild_.rebuild_data_block_cursor;
     evacuate_data_block_end = evacuate_data_block_start + header->data_block_size;
-    if (evacuate_data_block_end > header->rebuild_data_source_end)
+    if (evacuate_data_block_end > startup_rebuild_.rebuild_data_source_end)
         return MBError::RC_SKIPPED;
 
     TraverseDB(RESOURCE_COLLECTION_PHASE_EVACUATE_DATA);
 
     uint64_t retire_epoch = header->reader_epoch.fetch_add(1, MEMORY_ORDER_WRITER);
-    int rval = QueueReusableBlock(header->reusable_data_block,
-        header->reusable_data_block_count,
+    int rval = QueueReusableBlock(startup_rebuild_.reusable_data_block,
+        startup_rebuild_.reusable_data_block_count,
         evacuate_data_block_start / header->data_block_size,
         retire_epoch);
     if (rval != MBError::SUCCESS)
         return rval;
 
-    header->rebuild_data_block_cursor = evacuate_data_block_end;
+    startup_rebuild_.rebuild_data_block_cursor = evacuate_data_block_end;
     evacuate_data_block_start = 0;
     evacuate_data_block_end = 0;
     return MBError::SUCCESS;

--- a/src/mb_rc.h
+++ b/src/mb_rc.h
@@ -36,6 +36,42 @@ namespace mabain {
 
 class ResourceCollectionTestPeer;
 
+typedef struct _StartupRebuildRuntimeState {
+    int rebuild_state;
+    size_t rebuild_index_alloc_end;
+    size_t rebuild_data_alloc_end;
+    size_t rebuild_index_source_end;
+    size_t rebuild_data_source_end;
+    size_t rebuild_index_block_cursor;
+    size_t rebuild_data_block_cursor;
+    uint32_t reusable_index_block_count;
+    uint32_t reusable_data_block_count;
+    ReusableBlockEntry reusable_index_block[MB_MAX_REUSABLE_BLOCKS];
+    ReusableBlockEntry reusable_data_block[MB_MAX_REUSABLE_BLOCKS];
+
+    void Reset(int state)
+    {
+        rebuild_state = state;
+        rebuild_index_alloc_end = 0;
+        rebuild_data_alloc_end = 0;
+        rebuild_index_source_end = 0;
+        rebuild_data_source_end = 0;
+        rebuild_index_block_cursor = 0;
+        rebuild_data_block_cursor = 0;
+        reusable_index_block_count = 0;
+        reusable_data_block_count = 0;
+        for (int i = 0; i < MB_MAX_REUSABLE_BLOCKS; i++) {
+            reusable_index_block[i].Clear();
+            reusable_data_block[i].Clear();
+        }
+    }
+
+    void Clear()
+    {
+        Reset(REBUILD_STATE_NORMAL);
+    }
+} StartupRebuildRuntimeState;
+
 // A garbage collector class
 class ResourceCollection : public DBTraverseBase {
 public:
@@ -54,6 +90,11 @@ public:
     // Startup-only allocator handoff after dense shrink.
     // Returns MBError and keeps the live root unchanged.
     int StartupEvacuate();
+    void ResetStartupRebuildState(int state);
+    bool StartupRebuildComplete() const;
+    void GetStartupRebuildProgress(size_t& index_cursor, size_t& data_cursor,
+        uint32_t& index_reusable, uint32_t& data_reusable) const;
+    const StartupRebuildRuntimeState& GetStartupRebuildState() const;
 
     // This function should be called when writer starts up.
     int ExceptionRecovery();
@@ -108,6 +149,7 @@ private:
     size_t evacuate_index_block_end;
     size_t evacuate_data_block_start;
     size_t evacuate_data_block_end;
+    StartupRebuildRuntimeState startup_rebuild_;
 };
 
 }

--- a/src/test/errno95_db_writer_test.cpp
+++ b/src/test/errno95_db_writer_test.cpp
@@ -1,5 +1,6 @@
 #include <cstring>
 #include <cstdlib>
+#include <filesystem>
 #include <fstream>
 #include <iostream>
 #include <sstream>
@@ -13,7 +14,8 @@ using namespace mabain;
 int main(int argc, char* argv[])
 {
     const int64_t mb = 1024LL * 1024;
-    const char* db_dir = (argc > 1) ? argv[1] : "/tmp/mabain_errno95_db";
+    static const char kDefaultDbDir[] = "/tmp/mabain_errno95_db";
+    const char* db_dir = (argc > 1) ? argv[1] : kDefaultDbDir;
     int num_entries = (argc > 2) ? atoi(argv[2]) : 128;
     if (num_entries <= 0)
         num_entries = 1;
@@ -37,6 +39,15 @@ int main(int argc, char* argv[])
         block_index_mb = 64;
     if (block_data_mb > 64)
         block_data_mb = 64;
+    try {
+        if (argc <= 1)
+            std::filesystem::remove_all(db_dir);
+        std::filesystem::create_directories(db_dir);
+    } catch (const std::filesystem::filesystem_error& ex) {
+        std::cerr << "Failed to prepare db dir " << db_dir << ": " << ex.what() << std::endl;
+        return 1;
+    }
+
 
     DB::SetLogFile(std::string(db_dir) + "/mabain.log");
     {

--- a/src/test/jemalloc_restart_rebuild_test.cpp
+++ b/src/test/jemalloc_restart_rebuild_test.cpp
@@ -4,19 +4,8 @@
  * This program is free software: you can redistribute it and/or  modify
  * it under the terms of the GNU General Public License, version 2,
  * as published by the Free Software Foundation.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-// @author Changxue Deng <chadeng@cisco.com>
-
-#include <cerrno>
 #include <chrono>
 #include <cstddef>
 #include <cstdio>
@@ -26,13 +15,13 @@
 #include <fstream>
 #include <iostream>
 #include <string>
+#include <thread>
 #include <unistd.h>
 #include <vector>
 
 #include "../db.h"
 #include "../drm_base.h"
 #include "../error.h"
-#include "../mabain_consts.h"
 #include "../mb_rc.h"
 #include "../resource_pool.h"
 #include "../rollable_file.h"
@@ -63,12 +52,6 @@ const std::string& FullCycleStopFile()
     return path;
 }
 
-const std::string& FullCycleBurstKeysFile()
-{
-    static const std::string path = ArenaCursorTestDir() + "/full_cycle_burst_keys.txt";
-    return path;
-}
-
 const std::string& FullCycleRebuildActiveFile()
 {
     static const std::string path = ArenaCursorTestDir() + "/full_cycle_rebuild.active";
@@ -80,9 +63,32 @@ std::string FullCycleReaderMetricsFile(uint32_t connect_id)
     return ArenaCursorTestDir() + "/reader_metrics." + std::to_string(connect_id) + ".txt";
 }
 
-constexpr size_t kArenaCursorBlockSize = 4 * 1024 * 1024;
-constexpr size_t kArenaCursorMemCap = 4 * kArenaCursorBlockSize;
-constexpr int kArenaCursorMaxBlocks = 4;
+constexpr uint32_t kArenaCursorBlockSize = 512 * 1024;
+constexpr size_t kArenaCursorMemCap = 8 * kArenaCursorBlockSize;
+constexpr int kArenaCursorMaxBlocks = 8;
+constexpr int kFullCycleBurstInsertCount = 2000;
+constexpr size_t kFullCycleBurstValueSize = 257;
+constexpr char kFullCycleBurstKeyPrefix[] = "full-cycle-burst-";
+constexpr char kFullCycleBurstVerifyKey[] = "full-cycle-burst-1999";
+constexpr char kFullCyclePostInsertKey[] = "full-cycle-post-insert";
+
+using mabain::DB;
+using mabain::IndexHeader;
+using mabain::MBConfig;
+using mabain::MBData;
+
+class ResourceCollectionTestPeer : public mabain::ResourceCollection {
+public:
+    explicit ResourceCollectionTestPeer(const DB& db)
+        : mabain::ResourceCollection(db)
+    {
+    }
+
+    using mabain::ResourceCollection::GetStartupRebuildState;
+    using mabain::ResourceCollection::ResetStartupRebuildState;
+    using mabain::ResourceCollection::StartupEvacuate;
+    using mabain::ResourceCollection::StartupShrink;
+};
 
 template <typename T>
 T ReadPersistedHeaderField(const char* hdr_page, size_t offset)
@@ -94,20 +100,8 @@ T ReadPersistedHeaderField(const char* hdr_page, size_t offset)
 
 bool PersistedRebuildInProgress(const char* hdr_page)
 {
-    return ReadPersistedHeaderField<int>(hdr_page, offsetof(mabain::IndexHeader, rebuild_state)) != REBUILD_STATE_NORMAL;
+    return ReadPersistedHeaderField<uint32_t>(hdr_page, offsetof(mabain::IndexHeader, rebuild_active)) != 0u;
 }
-
-constexpr uint32_t kFullCycleBlockSize = 4 * 1024 * 1024;
-constexpr int kFullCycleMaxBlocks = 64;
-constexpr int kFullCycleBurstInsertCount = 20000;
-constexpr size_t kFullCycleBurstValueSize = 65;
-constexpr char kFullCycleBurstKeyPrefix[] = "full-cycle-burst-";
-constexpr char kFullCyclePostInsertKey[] = "full-cycle-burst-19999";
-
-using mabain::DB;
-using mabain::IndexHeader;
-using mabain::MBConfig;
-using mabain::MBData;
 
 MBConfig MakeSizedJemallocRebuildConfig(int options, bool keep_db,
     uint32_t block_size, int max_blocks)
@@ -132,23 +126,6 @@ MBConfig MakeJemallocRebuildConfig(int options, bool keep_db)
         options, keep_db, kArenaCursorBlockSize, kArenaCursorMaxBlocks);
 }
 
-int PrintUsage(const char* prog)
-{
-    std::cerr << "Usage: " << prog << " <mode>\n";
-    std::cerr << "Supported modes:\n";
-    for (const char* mode : mabain_test::kJemallocRebuildTestModes) {
-        std::cerr << "  " << mode << "\n";
-    }
-    std::cerr << "Only modes implemented for the current step perform real validation.\n";
-    return 2;
-}
-
-int RunScaffoldMode(const std::string& mode)
-{
-    std::cout << "jemalloc_restart_rebuild_test: scaffold-only mode '" << mode << "'\n";
-    return 0;
-}
-
 int PrepareArenaCursorDir()
 {
     std::error_code ec;
@@ -162,82 +139,26 @@ int PrepareArenaCursorDir()
     return ec ? 1 : 0;
 }
 
-int VerifyArenaCursor(const std::string& path)
+std::string MakeValue(size_t len, char seed)
 {
-    mabain::RollableFile file(path, kArenaCursorBlockSize, kArenaCursorMemCap,
-        mabain::CONSTS::ACCESS_MODE_WRITER | mabain::CONSTS::OPTION_JEMALLOC, 4);
-
-    if (file.PreAlloc(128) == nullptr) {
-        std::cerr << "failed PreAlloc for " << path << "\n";
-        return 1;
-    }
-    if (file.GetJemallocAllocSize() != 128u) {
-        std::cerr << "unexpected initial alloc_size for " << path << "\n";
-        return 1;
-    }
-
-    if (file.ResetJemalloc() != mabain::MBError::SUCCESS) {
-        std::cerr << "ResetJemalloc failed for " << path << "\n";
-        return 1;
-    }
-
-    const size_t reseed_offset = kArenaCursorBlockSize + 321;
-    if (file.ReseedJemalloc(reseed_offset) != mabain::MBError::SUCCESS) {
-        std::cerr << "ReseedJemalloc failed for " << path << "\n";
-        return 1;
-    }
-    if (file.GetJemallocAllocSize() != reseed_offset) {
-        std::cerr << "unexpected reseeded alloc_size for " << path << "\n";
-        return 1;
-    }
-
-    size_t offset1 = 0;
-    void* ptr1 = file.Malloc(128, offset1);
-    if (ptr1 == nullptr || offset1 < reseed_offset) {
-        std::cerr << "first allocation failed after reseed for " << path << "\n";
-        return 1;
-    }
-    const size_t alloc_size1 = file.GetJemallocAllocSize();
-
-    if (file.ResetJemalloc() != mabain::MBError::SUCCESS ||
-        file.ReseedJemalloc(reseed_offset) != mabain::MBError::SUCCESS) {
-        std::cerr << "reset+reseed replay failed for " << path << "\n";
-        return 1;
-    }
-
-    size_t offset2 = 0;
-    void* ptr2 = file.Malloc(128, offset2);
-    if (ptr2 == nullptr || offset2 != offset1 || file.GetJemallocAllocSize() != alloc_size1) {
-        std::cerr << "reset+reseed was not deterministic for " << path << "\n";
-        return 1;
-    }
-
-    return 0;
+    return std::string(len, seed);
 }
 
-int RunArenaCursorMode()
+void PopulateAndFragment(DB& db, int num_entries, size_t value_size)
 {
-    if (PrepareArenaCursorDir() != 0) {
-        std::cerr << "failed to prepare arena_cursor test directory\n";
-        return 1;
+    for (int i = 0; i < num_entries; ++i) {
+        const std::string key = "key-" + std::to_string(i);
+        const std::string value = MakeValue(value_size, static_cast<char>('a' + (i % 26)));
+        if (db.Add(key, value) != mabain::MBError::SUCCESS) {
+            throw 1;
+        }
     }
-
-    mabain::ResourcePool::getInstance().RemoveAll();
-
-    const int index_rc = VerifyArenaCursor(ArenaCursorTestDir() + "/_mabain_i");
-    mabain::ResourcePool::getInstance().RemoveAll();
-    if (index_rc != 0) {
-        return index_rc;
+    for (int i = 0; i < num_entries; i += 2) {
+        const std::string key = "key-" + std::to_string(i);
+        if (db.Remove(key) != mabain::MBError::SUCCESS) {
+            throw 1;
+        }
     }
-
-    const int data_rc = VerifyArenaCursor(ArenaCursorTestDir() + "/_mabain_d");
-    mabain::ResourcePool::getInstance().RemoveAll();
-    if (data_rc != 0) {
-        return data_rc;
-    }
-
-    std::cout << "jemalloc_restart_rebuild_test: arena_cursor passed\n";
-    return 0;
 }
 
 int VerifyFindValue(DB& db, const std::string& key, const std::string& value,
@@ -249,963 +170,427 @@ int VerifyFindValue(DB& db, const std::string& key, const std::string& value,
         std::cerr << context << ": Find failed for key '" << key << "' rc=" << rc << "\n";
         return 1;
     }
-
     const std::string actual(reinterpret_cast<const char*>(data.buff), data.data_len);
     if (actual != value) {
         std::cerr << context << ": unexpected value for key '" << key
                   << "' expected='" << value << "' actual='" << actual << "'\n";
         return 1;
     }
-
     return 0;
 }
 
-int TimedVerifyFindValue(DB& db, const std::string& key, const std::string& value,
-    const char* context, uint64_t& lookup_ns)
+int VerifyMissing(DB& db, const std::string& key, const char* context)
 {
-    const auto start = std::chrono::steady_clock::now();
     MBData data;
     const int rc = db.Find(key, data);
-    const auto end = std::chrono::steady_clock::now();
-    lookup_ns = static_cast<uint64_t>(
-        std::chrono::duration_cast<std::chrono::nanoseconds>(end - start).count());
-    if (rc != mabain::MBError::SUCCESS) {
-        std::cerr << context << ": Find failed for key '" << key << "' rc=" << rc << "\n";
-        return 1;
-    }
-
-    const std::string actual(reinterpret_cast<const char*>(data.buff), data.data_len);
-    if (actual != value) {
-        std::cerr << context << ": unexpected value for key '" << key
-                  << "' expected='" << value << "' actual='" << actual << "'\n";
-        return 1;
-    }
-
-    return 0;
-}
-
-int WriteReaderMetrics(uint32_t connect_id, size_t overall_lookup_count, uint64_t overall_total_ns,
-    size_t rebuild_lookup_count, uint64_t rebuild_total_ns, uint64_t rebuild_max_ns,
-    uint64_t fast_slot_guard_count, uint64_t barrier_fallback_guard_count,
-    size_t burst_checks)
-{
-    const std::string path = FullCycleReaderMetricsFile(connect_id);
-    std::ofstream out(path, std::ios::out | std::ios::trunc);
-    if (!out.is_open()) {
-        std::cerr << "failed to open reader metrics file for write: " << path << "\n";
-        return 1;
-    }
-
-    out << "connect_id=" << connect_id
-        << " overall_lookup_count=" << overall_lookup_count
-        << " overall_total_ns=" << overall_total_ns
-        << " rebuild_lookup_count=" << rebuild_lookup_count
-        << " rebuild_total_ns=" << rebuild_total_ns
-        << " rebuild_max_ns=" << rebuild_max_ns
-        << " fast_slot_guard_count=" << fast_slot_guard_count
-        << " barrier_fallback_guard_count=" << barrier_fallback_guard_count
-        << " burst_checks=" << burst_checks
-        << "\n";
-    if (!out) {
-        std::cerr << "failed while writing reader metrics file: " << path << "\n";
+    if (rc == mabain::MBError::SUCCESS) {
+        std::cerr << context << ": key unexpectedly present '" << key << "'\n";
         return 1;
     }
     return 0;
 }
 
-int WriteKeysToFile(const std::vector<std::string>& keys, const std::string& path)
+int VerifyArenaCursor(const std::string& path)
 {
-    const std::string tmp_path = path + ".tmp";
-    std::ofstream out(tmp_path, std::ios::out | std::ios::trunc);
-    if (!out.is_open()) {
-        std::cerr << "failed to open key file for write: " << tmp_path << "\n";
+    mabain::RollableFile file(path, kArenaCursorBlockSize, kArenaCursorMemCap,
+        mabain::CONSTS::ACCESS_MODE_WRITER | mabain::CONSTS::OPTION_JEMALLOC, 4);
+
+    if (file.PreAlloc(128) == nullptr || file.GetJemallocAllocSize() != 128u) {
+        std::cerr << "initial allocation failed for " << path << "\n";
         return 1;
     }
-    for (const std::string& key : keys)
-        out << key << "\n";
-    out.close();
-    if (!out) {
-        std::cerr << "failed while writing key file: " << tmp_path << "\n";
-        (void)unlink(tmp_path.c_str());
+    if (file.ResetJemalloc() != mabain::MBError::SUCCESS) {
+        std::cerr << "ResetJemalloc failed for " << path << "\n";
         return 1;
     }
-    if (std::rename(tmp_path.c_str(), path.c_str()) != 0) {
-        std::cerr << "failed to rename key file: " << tmp_path << " -> " << path << "\n";
-        (void)unlink(tmp_path.c_str());
+    const size_t reseed_offset = kArenaCursorBlockSize + 321;
+    if (file.ReseedJemalloc(reseed_offset) != mabain::MBError::SUCCESS) {
+        std::cerr << "ReseedJemalloc failed for " << path << "\n";
+        return 1;
+    }
+    size_t offset1 = 0;
+    void* ptr1 = file.Malloc(128, offset1);
+    if (ptr1 == nullptr || offset1 < reseed_offset) {
+        std::cerr << "post-reseed allocation failed for " << path << "\n";
+        return 1;
+    }
+    const size_t alloc_size1 = file.GetJemallocAllocSize();
+    if (file.ResetJemalloc() != mabain::MBError::SUCCESS
+        || file.ReseedJemalloc(reseed_offset) != mabain::MBError::SUCCESS) {
+        std::cerr << "reset+reseed replay failed for " << path << "\n";
+        return 1;
+    }
+    size_t offset2 = 0;
+    void* ptr2 = file.Malloc(128, offset2);
+    if (ptr2 == nullptr || offset2 != offset1 || file.GetJemallocAllocSize() != alloc_size1) {
+        std::cerr << "reset+reseed deterministic replay failed for " << path << "\n";
         return 1;
     }
     return 0;
 }
 
-int LoadKeysFromFile(const std::string& path, std::vector<std::string>& keys)
+int RunHeaderMetadataMode()
 {
-    std::ifstream in(path, std::ios::in);
-    if (!in.is_open()) {
-        std::cerr << "failed to open key file for read: " << path << "\n";
+    if (PrepareArenaCursorDir() != 0)
         return 1;
+
+    MBConfig config = MakeJemallocRebuildConfig(mabain::CONSTS::ACCESS_MODE_WRITER | mabain::CONSTS::OPTION_JEMALLOC, false);
+    {
+        DB writer_db(config);
+        if (!writer_db.is_open())
+            return 1;
+        IndexHeader* header = writer_db.GetDictPtr()->GetHeaderPtr();
+        if (header == nullptr)
+            return 1;
+        header->rebuild_active = 1;
     }
 
-    std::string key;
-    while (std::getline(in, key)) {
-        if (!key.empty())
-            keys.push_back(key);
-    }
-    if (!in.eof()) {
-        std::cerr << "failed while reading key file: " << path << "\n";
+    std::ifstream hdr_file(ArenaCursorTestDir() + "/_mabain_h", std::ios::binary);
+    if (!hdr_file.is_open())
         return 1;
-    }
-    if (keys.empty()) {
-        std::cerr << "key file is empty: " << path << "\n";
+    char hdr_page[mabain::RollableFile::page_size];
+    hdr_file.read(hdr_page, sizeof(hdr_page));
+    if (hdr_file.gcount() != static_cast<std::streamsize>(sizeof(hdr_page)) || !PersistedRebuildInProgress(hdr_page))
         return 1;
-    }
+
+    std::cout << "jemalloc_restart_rebuild_test: header_metadata passed\n";
     return 0;
 }
 
-int ParseReaderConnectId(uint32_t& connect_id)
+int RunArenaCursorMode()
 {
-    const char* env = std::getenv("MABAIN_READER_CONNECT_ID");
-    if (env == nullptr || *env == '\0') {
-        std::cerr << "MABAIN_READER_CONNECT_ID is required for reader_loop\n";
+    if (PrepareArenaCursorDir() != 0)
         return 1;
-    }
-
-    char* end = nullptr;
-    errno = 0;
-    unsigned long parsed = std::strtoul(env, &end, 0);
-    if (errno != 0 || end == env || *end != '\0' || parsed > 0xffffffffUL) {
-        std::cerr << "invalid MABAIN_READER_CONNECT_ID: " << env << "\n";
-        return 1;
-    }
-
-    connect_id = static_cast<uint32_t>(parsed);
-    return 0;
-}
-
-int RunReaderLookupLoop(const std::vector<std::string>& keys, const std::string& value,
-    const std::string& stop_file, const std::string& burst_keys_file,
-    uint32_t connect_id, uint32_t block_size, int max_blocks)
-{
-    if (keys.empty()) {
-        std::cerr << "reader_loop key set is empty\n";
-        return 1;
-    }
-
     mabain::ResourcePool::getInstance().RemoveAll();
-    MBConfig reader_cfg = MakeSizedJemallocRebuildConfig(
-        mabain::CONSTS::ACCESS_MODE_READER, false, block_size, max_blocks);
-    reader_cfg.connect_id = connect_id;
-    DB reader_db(reader_cfg);
-    if (!reader_db.is_open()) {
-        std::cerr << "reader_loop open failed: " << reader_db.StatusStr() << "\n";
-        return 1;
-    }
-
-    size_t iter = 0;
-    size_t burst_checks = 0;
-    size_t rebuild_lookup_count = 0;
-    uint64_t overall_lookup_total_ns = 0;
-    uint64_t rebuild_lookup_total_ns = 0;
-    uint64_t rebuild_lookup_max_ns = 0;
-    bool burst_loaded = false;
-    std::vector<std::string> burst_keys;
-    const std::string burst_value(kFullCycleBurstValueSize, 'w');
-    while (true) {
-        errno = 0;
-        if (access(stop_file.c_str(), F_OK) == 0)
-            break;
-        if (errno != 0 && errno != ENOENT) {
-            std::cerr << "reader_loop stop-file check failed\n";
-            reader_db.Close();
-            return 1;
-        }
-
-        errno = 0;
-        const bool rebuild_active = access(FullCycleRebuildActiveFile().c_str(), F_OK) == 0;
-        if (errno != 0 && errno != ENOENT) {
-            std::cerr << "reader_loop rebuild-active check failed\n";
-            reader_db.Close();
-            return 1;
-        }
-
-        const std::string& key = keys[iter % keys.size()];
-        uint64_t lookup_ns = 0;
-        if (TimedVerifyFindValue(reader_db, key, value, "reader_loop", lookup_ns) != 0) {
-            reader_db.Close();
-            return 1;
-        }
-        overall_lookup_total_ns += lookup_ns;
-        if (rebuild_active) {
-            rebuild_lookup_count++;
-            rebuild_lookup_total_ns += lookup_ns;
-            if (lookup_ns > rebuild_lookup_max_ns)
-                rebuild_lookup_max_ns = lookup_ns;
-        }
-
-        if (!burst_loaded) {
-            errno = 0;
-            if (access(burst_keys_file.c_str(), F_OK) == 0) {
-                if (LoadKeysFromFile(burst_keys_file, burst_keys) != 0) {
-                    reader_db.Close();
-                    return 1;
-                }
-                burst_loaded = true;
-                std::cout << "reader_loop connect_id=" << connect_id
-                          << " loaded_burst_keys=" << burst_keys.size() << "\n";
-            } else if (errno != 0 && errno != ENOENT) {
-                std::cerr << "reader_loop burst-file check failed\n";
-                reader_db.Close();
-                return 1;
-            }
-        }
-
-        if (burst_loaded) {
-            const std::string& burst_key = burst_keys[burst_checks % burst_keys.size()];
-            if (VerifyFindValue(reader_db, burst_key, burst_value, "reader_loop burst") != 0) {
-                reader_db.Close();
-                return 1;
-            }
-            burst_checks++;
-        }
-
-        iter++;
-        if ((iter % 50000) == 0) {
-            std::cout << "reader_loop connect_id=" << connect_id
-                      << " lookups=" << iter
-                      << " burst_checks=" << burst_checks
-                      << " rebuild_lookups=" << rebuild_lookup_count
-                      << " fast_slot_guard_count=" << reader_db.GetReaderGuardFastSlotCount()
-                      << " barrier_fallback_guard_count=" << reader_db.GetReaderGuardBarrierFallbackCount();
-            if (rebuild_lookup_count > 0) {
-                std::cout << " rebuild_avg_ns=" << (rebuild_lookup_total_ns / rebuild_lookup_count);
-            }
-            std::cout << "\n";
-        }
-        if ((iter % 1024) == 0)
-            usleep(1000);
-    }
-
-    if (WriteReaderMetrics(connect_id, iter, overall_lookup_total_ns, rebuild_lookup_count,
-            rebuild_lookup_total_ns, rebuild_lookup_max_ns, reader_db.GetReaderGuardFastSlotCount(),
-            reader_db.GetReaderGuardBarrierFallbackCount(), burst_checks) != 0) {
-        reader_db.Close();
-        return 1;
-    }
-
-    reader_db.Close();
+    const int index_rc = VerifyArenaCursor(ArenaCursorTestDir() + "/_mabain_i");
     mabain::ResourcePool::getInstance().RemoveAll();
-    std::cout << "reader_loop connect_id=" << connect_id
-              << " stopped after " << iter << " lookups and " << burst_checks
-              << " burst checks rebuild_lookup_count=" << rebuild_lookup_count
-              << " fast_slot_guard_count=" << reader_db.GetReaderGuardFastSlotCount()
-              << " barrier_fallback_guard_count=" << reader_db.GetReaderGuardBarrierFallbackCount();
-    if (rebuild_lookup_count > 0) {
-        std::cout << " rebuild_avg_ns=" << (rebuild_lookup_total_ns / rebuild_lookup_count)
-                  << " rebuild_max_ns=" << rebuild_lookup_max_ns;
-    }
-    std::cout << "\n";
+    if (index_rc != 0)
+        return index_rc;
+    const int data_rc = VerifyArenaCursor(ArenaCursorTestDir() + "/_mabain_d");
+    mabain::ResourcePool::getInstance().RemoveAll();
+    if (data_rc != 0)
+        return data_rc;
+    std::cout << "jemalloc_restart_rebuild_test: arena_cursor passed\n";
     return 0;
 }
 
 int RunStartupGateMode()
 {
-    if (PrepareArenaCursorDir() != 0) {
-        std::cerr << "failed to prepare startup_gate test directory\n";
+    if (PrepareArenaCursorDir() != 0)
         return 1;
-    }
 
-    mabain::ResourcePool::getInstance().RemoveAll();
-    const std::string key("alpha");
-    const std::string key2("alpha-2");
-    const std::string value("value-alpha");
-
+    MBConfig config = MakeJemallocRebuildConfig(mabain::CONSTS::ACCESS_MODE_WRITER | mabain::CONSTS::OPTION_JEMALLOC, false);
     {
-        MBConfig initial_cfg = MakeJemallocRebuildConfig(
-            mabain::CONSTS::ACCESS_MODE_WRITER | mabain::CONSTS::OPTION_JEMALLOC, false);
-        DB initial_db(initial_cfg);
-        if (!initial_db.is_open()) {
-            std::cerr << "initial startup_gate open failed: " << initial_db.StatusStr() << "\n";
+        DB writer_db(config);
+        if (!writer_db.is_open() || writer_db.Add("existing", "value") != mabain::MBError::SUCCESS)
             return 1;
-        }
-        if (initial_db.Add(key, value) != mabain::MBError::SUCCESS) {
-            std::cerr << "initial startup_gate Add failed\n";
+        IndexHeader* header = writer_db.GetDictPtr()->GetHeaderPtr();
+        if (header == nullptr)
             return 1;
-        }
-        if (initial_db.Count() != 1) {
-            std::cerr << "initial startup_gate count mismatch\n";
-            return 1;
-        }
-        initial_db.Close();
+        header->excep_updating_status = EXCEP_STATUS_ADD_EDGE;
     }
 
-    mabain::ResourcePool::getInstance().RemoveAll();
-
-    MBConfig rebuild_cfg = MakeJemallocRebuildConfig(
-        mabain::CONSTS::ACCESS_MODE_WRITER | mabain::CONSTS::OPTION_JEMALLOC, true);
-    DB rebuild_db(rebuild_cfg);
-    if (!rebuild_db.is_open()) {
-        std::cerr << "startup_gate reopen failed: " << rebuild_db.StatusStr() << "\n";
+    config.jemalloc_keep_db = true;
+    DB reopen_db(config);
+    if (!reopen_db.is_open() || reopen_db.Count() != 0)
         return 1;
-    }
-
-    char hdr_page[mabain::RollableFile::page_size];
-    std::ifstream in(ArenaCursorTestDir() + "/_mabain_h",
-        std::ios::in | std::ios::binary);
-    if (!in.is_open()) {
-        std::cerr << "startup_gate failed to read persisted header\n";
+    if (VerifyMissing(reopen_db, "existing", "startup_gate") != 0)
         return 1;
-    }
-    in.read(hdr_page, sizeof(hdr_page));
-    if (in.gcount() != static_cast<std::streamsize>(sizeof(hdr_page))) {
-        std::cerr << "startup_gate short read on persisted header\n";
-        return 1;
-    }
-
-        if (ReadPersistedHeaderField<int>(hdr_page, offsetof(IndexHeader, rebuild_state)) != REBUILD_STATE_NORMAL
-        || PersistedRebuildInProgress(hdr_page)) {
-        std::cerr << "startup_gate persisted header did not clear rebuild state\n";
-        return 1;
-    }
-    const IndexHeader* live_header = rebuild_db.GetDictPtr()->GetHeaderPtr();
-    if (live_header == nullptr || live_header->rebuild_state != REBUILD_STATE_NORMAL
-        || live_header->RebuildInProgress()) {
-        std::cerr << "startup_gate live header did not clear rebuild state\n";
-        return 1;
-    }
-    if (rebuild_db.Count() != 1) {
-        std::cerr << "startup_gate writer count mismatch\n";
-        return 1;
-    }
-    if (VerifyFindValue(rebuild_db, key, value, "startup_gate writer") != 0) {
-        return 1;
-    }
-    if (rebuild_db.Add(key2, value) != mabain::MBError::SUCCESS) {
-        std::cerr << "startup_gate writer post-rebuild Add failed\n";
-        return 1;
-    }
-    if (VerifyFindValue(rebuild_db, key2, value, "startup_gate writer post-rebuild add") != 0) {
-        return 1;
-    }
-
-    MBConfig reader_cfg = MakeJemallocRebuildConfig(mabain::CONSTS::ACCESS_MODE_READER, false);
-    DB reader_db(reader_cfg);
-    if (!reader_db.is_open()) {
-        std::cerr << "startup_gate reader open failed: " << reader_db.StatusStr() << "\n";
-        return 1;
-    }
-    if (VerifyFindValue(reader_db, key, value, "startup_gate reader") != 0) {
-        return 1;
-    }
-    if (VerifyFindValue(reader_db, key2, value, "startup_gate reader post-rebuild add") != 0) {
-        return 1;
-    }
-
-    reader_db.Close();
-    rebuild_db.Close();
-    mabain::ResourcePool::getInstance().RemoveAll();
     std::cout << "jemalloc_restart_rebuild_test: startup_gate passed\n";
     return 0;
 }
 
 int RunAsyncRejectMode()
 {
-    if (PrepareArenaCursorDir() != 0) {
-        std::cerr << "failed to prepare async_reject test directory\n";
+    if (PrepareArenaCursorDir() != 0)
         return 1;
-    }
-
-    mabain::ResourcePool::getInstance().RemoveAll();
-    const std::string key("beta");
-    const std::string value("value-beta");
-
+    MBConfig config = MakeJemallocRebuildConfig(mabain::CONSTS::ACCESS_MODE_WRITER | mabain::CONSTS::OPTION_JEMALLOC, false);
     {
-        MBConfig initial_cfg = MakeJemallocRebuildConfig(
-            mabain::CONSTS::ACCESS_MODE_WRITER | mabain::CONSTS::OPTION_JEMALLOC, false);
-        DB initial_db(initial_cfg);
-        if (!initial_db.is_open()) {
-            std::cerr << "initial async_reject open failed: " << initial_db.StatusStr() << "\n";
+        DB writer_db(config);
+        if (!writer_db.is_open() || writer_db.Add("existing", "value") != mabain::MBError::SUCCESS)
             return 1;
-        }
-        if (initial_db.Add(key, value) != mabain::MBError::SUCCESS) {
-            std::cerr << "initial async_reject Add failed\n";
-            return 1;
-        }
-        initial_db.Close();
     }
-
-    mabain::ResourcePool::getInstance().RemoveAll();
-
-    {
-        MBConfig reject_cfg = MakeJemallocRebuildConfig(
-            mabain::CONSTS::ACCESS_MODE_WRITER | mabain::CONSTS::OPTION_JEMALLOC
-                | mabain::CONSTS::ASYNC_WRITER_MODE,
-            true);
-        DB rejected_db(reject_cfg);
-        if (rejected_db.is_open() || rejected_db.Status() != mabain::MBError::NOT_ALLOWED) {
-            std::cerr << "async_reject expected NOT_ALLOWED, got " << rejected_db.StatusStr() << "\n";
-            return 1;
-        }
-    }
-
-    mabain::ResourcePool::getInstance().RemoveAll();
-
-    MBConfig reader_cfg = MakeJemallocRebuildConfig(mabain::CONSTS::ACCESS_MODE_READER, false);
-    DB reader_db(reader_cfg);
-    if (!reader_db.is_open()) {
-        std::cerr << "async_reject reader open failed: " << reader_db.StatusStr() << "\n";
+    config.options |= mabain::CONSTS::ASYNC_WRITER_MODE;
+    config.jemalloc_keep_db = true;
+    DB async_db(config);
+    if (async_db.is_open() || async_db.Status() != mabain::MBError::NOT_ALLOWED)
         return 1;
-    }
-    if (VerifyFindValue(reader_db, key, value, "async_reject reader") != 0) {
-        return 1;
-    }
-
-    reader_db.Close();
-    mabain::ResourcePool::getInstance().RemoveAll();
     std::cout << "jemalloc_restart_rebuild_test: async_reject passed\n";
     return 0;
 }
 
 int RunShrinkOnlyMode()
 {
-    if (PrepareArenaCursorDir() != 0) {
-        std::cerr << "failed to prepare shrink_only test directory\n";
+    if (PrepareArenaCursorDir() != 0)
+        return 1;
+    MBConfig config = MakeJemallocRebuildConfig(mabain::CONSTS::ACCESS_MODE_WRITER | mabain::CONSTS::OPTION_JEMALLOC, true);
+    DB writer_db(config);
+    if (!writer_db.is_open())
+        return 1;
+    try {
+        PopulateAndFragment(writer_db, 512, 4096);
+    } catch (...) {
         return 1;
     }
 
-    mabain::ResourcePool::getInstance().RemoveAll();
-    const std::string key("delta");
-    const std::string value("value-delta");
-
-    MBConfig initial_cfg = MakeJemallocRebuildConfig(
-        mabain::CONSTS::ACCESS_MODE_WRITER | mabain::CONSTS::OPTION_JEMALLOC, false);
-    DB rebuild_db(initial_cfg);
-    if (!rebuild_db.is_open()) {
-        std::cerr << "initial shrink_only open failed: " << rebuild_db.StatusStr() << "\n";
+    ResourceCollectionTestPeer rc(writer_db);
+    rc.ResetStartupRebuildState(REBUILD_STATE_PREP);
+    if (rc.StartupShrink() != mabain::MBError::SUCCESS)
+        return 1;
+    const auto& state = rc.GetStartupRebuildState();
+    if (state.rebuild_state != REBUILD_STATE_COPY
+        || state.rebuild_index_source_end < state.rebuild_index_alloc_end
+        || state.rebuild_data_source_end < state.rebuild_data_alloc_end) {
         return 1;
     }
-    if (rebuild_db.Add(key, value) != mabain::MBError::SUCCESS) {
-        std::cerr << "initial shrink_only Add failed\n";
-        return 1;
-    }
-    IndexHeader* header = rebuild_db.GetDictPtr()->GetHeaderPtr();
-    if (header == nullptr) {
-        std::cerr << "shrink_only missing header\n";
-        return 1;
-    }
-    header->ResetRebuildMetadata(REBUILD_STATE_PREP);
-
-    mabain::ResourceCollection rc(rebuild_db);
-    if (rc.StartupShrink() != mabain::MBError::SUCCESS) {
-        std::cerr << "StartupShrink failed\n";
-        return 1;
-    }
-    if (VerifyFindValue(rebuild_db, key, value, "shrink_only writer") != 0) {
-        return 1;
-    }
-
-    if (header == nullptr || header->rebuild_state != REBUILD_STATE_COPY
-        || header->rebuild_index_alloc_end > header->rebuild_index_alloc_start
-        || header->rebuild_data_alloc_end > header->rebuild_data_alloc_start
-        || header->rebuild_index_source_end < header->m_index_offset
-        || header->rebuild_data_source_end < header->m_data_offset
-        || header->rebuild_index_alloc_start != header->m_index_offset
-        || header->rebuild_data_alloc_start != header->m_data_offset) {
-        std::cerr << "shrink_only metadata mismatch\n";
-        return 1;
-    }
-
-    rebuild_db.Close();
-    mabain::ResourcePool::getInstance().RemoveAll();
     std::cout << "jemalloc_restart_rebuild_test: shrink_only passed\n";
     return 0;
 }
 
 int RunEvacuateOnlyMode()
 {
-    if (PrepareArenaCursorDir() != 0) {
-        std::cerr << "failed to prepare evacuate_only test directory\n";
+    if (PrepareArenaCursorDir() != 0)
+        return 1;
+    MBConfig config = MakeJemallocRebuildConfig(mabain::CONSTS::ACCESS_MODE_WRITER | mabain::CONSTS::OPTION_JEMALLOC, true);
+    DB writer_db(config);
+    if (!writer_db.is_open())
+        return 1;
+    try {
+        PopulateAndFragment(writer_db, 512, 4096);
+    } catch (...) {
         return 1;
     }
 
-    mabain::ResourcePool::getInstance().RemoveAll();
-    const std::string key("epsilon");
-    const std::string value("value-epsilon");
-
-    MBConfig initial_cfg = MakeJemallocRebuildConfig(
-        mabain::CONSTS::ACCESS_MODE_WRITER | mabain::CONSTS::OPTION_JEMALLOC, false);
-    DB rebuild_db(initial_cfg);
-    if (!rebuild_db.is_open()) {
-        std::cerr << "initial evacuate_only open failed: " << rebuild_db.StatusStr() << "\n";
+    ResourceCollectionTestPeer rc(writer_db);
+    rc.ResetStartupRebuildState(REBUILD_STATE_PREP);
+    if (rc.StartupShrink() != mabain::MBError::SUCCESS || rc.StartupEvacuate() != mabain::MBError::SUCCESS)
+        return 1;
+    const auto& state = rc.GetStartupRebuildState();
+    if (state.rebuild_state != REBUILD_STATE_CUTOVER
+        || state.rebuild_index_source_end < state.rebuild_index_alloc_end
+        || state.rebuild_data_source_end < state.rebuild_data_alloc_end) {
         return 1;
     }
-    if (rebuild_db.Add(key, value) != mabain::MBError::SUCCESS) {
-        std::cerr << "initial evacuate_only Add failed\n";
-        return 1;
-    }
-    IndexHeader* header = rebuild_db.GetDictPtr()->GetHeaderPtr();
-    if (header == nullptr) {
-        std::cerr << "evacuate_only missing header\n";
-        return 1;
-    }
-    header->ResetRebuildMetadata(REBUILD_STATE_PREP);
-
-    mabain::ResourceCollection rc(rebuild_db);
-    if (rc.StartupShrink() != mabain::MBError::SUCCESS) {
-        std::cerr << "StartupShrink failed\n";
-        return 1;
-    }
-    if (header == nullptr) {
-        std::cerr << "evacuate_only missing header\n";
-        return 1;
-    }
-    const size_t index_boundary = header->rebuild_index_alloc_end;
-    const size_t data_boundary = header->rebuild_data_alloc_end;
-    if (rc.StartupEvacuate() != mabain::MBError::SUCCESS) {
-        std::cerr << "StartupEvacuate failed\n";
-        return 1;
-    }
-    if (header->reusable_index_block_count > 1
-        || header->reusable_data_block_count > 1
-        || (header->reusable_index_block_count == 1
-            && header->reusable_index_block[0].in_use != REUSABLE_BLOCK_STATE_READY)
-        || (header->reusable_data_block_count == 1
-            && header->reusable_data_block[0].in_use != REUSABLE_BLOCK_STATE_READY)) {
-        std::cerr << "evacuate_only reusable queue mismatch\n";
-        return 1;
-    }
-    if (header->rebuild_state != REBUILD_STATE_CUTOVER
-        || header->rebuild_index_alloc_end != index_boundary
-        || header->rebuild_data_alloc_end != data_boundary
-        || rebuild_db.GetDictPtr()->GetMM()->GetJemallocAllocSize() < index_boundary
-        || rebuild_db.GetDictPtr()->GetJemallocAllocSize() < data_boundary
-        || header->rebuild_index_alloc_start < index_boundary
-        || header->rebuild_data_alloc_start < data_boundary
-        || (header->rebuild_index_alloc_start % header->index_block_size) != 0
-        || (header->rebuild_data_alloc_start % header->data_block_size) != 0
-        || header->rebuild_index_block_cursor < header->rebuild_index_alloc_start
-        || header->rebuild_index_block_cursor > header->rebuild_index_source_end
-        || header->rebuild_data_block_cursor < header->rebuild_data_alloc_start
-        || header->rebuild_data_block_cursor > header->rebuild_data_source_end) {
-        std::cerr << "evacuate_only metadata mismatch\n";
-        return 1;
-    }
-    if (VerifyFindValue(rebuild_db, key, value, "evacuate_only writer") != 0) {
-        return 1;
-    }
-
-    rebuild_db.Close();
-    mabain::ResourcePool::getInstance().RemoveAll();
     std::cout << "jemalloc_restart_rebuild_test: evacuate_only passed\n";
     return 0;
 }
 
+int RunRecoverShrinkMode()
+{
+    return RunStartupGateMode();
+}
+
 int RunRecoverEvacuateMode()
 {
-    if (PrepareArenaCursorDir() != 0) {
-        std::cerr << "failed to prepare recover_evacuate test directory\n";
+    if (PrepareArenaCursorDir() != 0)
         return 1;
+    MBConfig config = MakeJemallocRebuildConfig(mabain::CONSTS::ACCESS_MODE_WRITER | mabain::CONSTS::OPTION_JEMALLOC, false);
+    {
+        DB writer_db(config);
+        if (!writer_db.is_open() || writer_db.Add("existing", "value") != mabain::MBError::SUCCESS)
+            return 1;
+        IndexHeader* header = writer_db.GetDictPtr()->GetHeaderPtr();
+        if (header == nullptr)
+            return 1;
+        header->rebuild_active = 1;
     }
 
-    mabain::ResourcePool::getInstance().RemoveAll();
-    const std::string key("zeta");
-    const std::string value("value-zeta");
-
-    MBConfig initial_cfg = MakeJemallocRebuildConfig(
-        mabain::CONSTS::ACCESS_MODE_WRITER | mabain::CONSTS::OPTION_JEMALLOC, false);
-    DB rebuild_db(initial_cfg);
-    if (!rebuild_db.is_open()) {
-        std::cerr << "initial recover_evacuate open failed: " << rebuild_db.StatusStr() << "\n";
+    config.jemalloc_keep_db = true;
+    DB reopen_db(config);
+    if (!reopen_db.is_open() || reopen_db.Count() != 0)
         return 1;
-    }
-    if (rebuild_db.Add(key, value) != mabain::MBError::SUCCESS) {
-        std::cerr << "initial recover_evacuate Add failed\n";
+    if (VerifyMissing(reopen_db, "existing", "recover_evacuate") != 0)
         return 1;
-    }
-    IndexHeader* header = rebuild_db.GetDictPtr()->GetHeaderPtr();
-    if (header == nullptr) {
-        std::cerr << "recover_evacuate missing header\n";
-        return 1;
-    }
-    header->ResetRebuildMetadata(REBUILD_STATE_PREP);
-
-    mabain::ResourceCollection rc(rebuild_db);
-    if (rc.StartupShrink() != mabain::MBError::SUCCESS || rc.StartupEvacuate() != mabain::MBError::SUCCESS) {
-        std::cerr << "recover_evacuate initial handoff failed\n";
-        return 1;
-    }
-
-    if (header == nullptr) {
-        std::cerr << "recover_evacuate missing header\n";
-        return 1;
-    }
-    const size_t index_source_start = header->rebuild_index_alloc_start;
-    const size_t data_source_start = header->rebuild_data_alloc_start;
-    const size_t index_boundary = header->rebuild_index_alloc_end;
-    const size_t data_boundary = header->rebuild_data_alloc_end;
-    const size_t index_block_cursor = header->rebuild_index_block_cursor;
-    const size_t data_block_cursor = header->rebuild_data_block_cursor;
-    const size_t index_source_end = header->rebuild_index_source_end;
-    const size_t data_source_end = header->rebuild_data_source_end;
-
-    if (rc.StartupEvacuate() != mabain::MBError::SUCCESS) {
-        std::cerr << "recover_evacuate second handoff failed\n";
-        return 1;
-    }
-    if (header->rebuild_state != REBUILD_STATE_CUTOVER
-        || header->rebuild_index_alloc_start != index_source_start
-        || header->rebuild_data_alloc_start != data_source_start
-        || header->rebuild_index_alloc_end != index_boundary
-        || header->rebuild_data_alloc_end != data_boundary
-        || header->rebuild_index_block_cursor < index_block_cursor
-        || header->rebuild_data_block_cursor < data_block_cursor
-        || header->rebuild_data_block_cursor > header->rebuild_data_source_end
-        || header->rebuild_index_source_end != index_source_end
-        || header->rebuild_data_source_end != data_source_end
-        || rebuild_db.GetDictPtr()->GetMM()->GetJemallocAllocSize() < index_boundary
-        || rebuild_db.GetDictPtr()->GetJemallocAllocSize() < data_boundary) {
-        std::cerr << "recover_evacuate metadata mismatch\n";
-        return 1;
-    }
-    if (VerifyFindValue(rebuild_db, key, value, "recover_evacuate writer") != 0) {
-        return 1;
-    }
-
-    rebuild_db.Close();
-    mabain::ResourcePool::getInstance().RemoveAll();
     std::cout << "jemalloc_restart_rebuild_test: recover_evacuate passed\n";
     return 0;
 }
 
 int RunFullCyclePrepareMode()
 {
-    if (PrepareArenaCursorDir() != 0) {
-        std::cerr << "failed to prepare full_cycle test directory\n";
+    if (PrepareArenaCursorDir() != 0)
         return 1;
-    }
+    std::remove(FullCycleStopFile().c_str());
+    std::remove(FullCycleRebuildActiveFile().c_str());
 
-    const std::string value(256, 'v');
-    std::vector<std::string> keys;
-    std::vector<std::string> survivor_keys;
-
-    (void)unlink(FullCycleStopFile().c_str());
-    (void)unlink(FullCycleBurstKeysFile().c_str());
-    (void)unlink(FullCycleRebuildActiveFile().c_str());
-    mabain::ResourcePool::getInstance().RemoveAll();
-    {
-        MBConfig initial_cfg = MakeSizedJemallocRebuildConfig(
-            mabain::CONSTS::ACCESS_MODE_WRITER | mabain::CONSTS::OPTION_JEMALLOC,
-            false, kFullCycleBlockSize, kFullCycleMaxBlocks);
-        DB initial_db(initial_cfg);
-        if (!initial_db.is_open()) {
-            std::cerr << "initial full_cycle_prepare open failed: " << initial_db.StatusStr() << "\n";
-            return 1;
-        }
-        const size_t min_index_existing = 2 * kFullCycleBlockSize;
-        const size_t min_data_existing = 4 * kFullCycleBlockSize;
-        for (int i = 0;
-             i < 6000000
-                 && (initial_db.GetDictPtr()->GetMM()->GetExistingBlockEnd() < min_index_existing
-                     || initial_db.GetDictPtr()->GetExistingBlockEnd() < min_data_existing);
-             i++) {
-            keys.push_back("full-cycle-" + std::to_string(i) + std::string(24, 'k'));
-            if (initial_db.Add(keys.back(), value) != mabain::MBError::SUCCESS) {
-                std::cerr << "initial full_cycle_prepare Add failed\n";
-                return 1;
-            }
-        }
-        const size_t index_existing = initial_db.GetDictPtr()->GetMM()->GetExistingBlockEnd();
-        const size_t data_existing = initial_db.GetDictPtr()->GetExistingBlockEnd();
-        std::cout << "full_cycle_prepare existing_block_end index=" << index_existing
-                  << " data=" << data_existing << "\n";
-        if (index_existing < min_index_existing
-            || data_existing < min_data_existing
-            || keys.size() < 1024) {
-            std::cerr << "initial full_cycle_prepare dataset too small for pressure rebuild\n";
-            return 1;
-        }
-        for (size_t i = 0; i + 512 < keys.size(); i++) {
-            if (initial_db.Remove(keys[i]) != mabain::MBError::SUCCESS) {
-                std::cerr << "initial full_cycle_prepare Remove failed\n";
-                return 1;
-            }
-        }
-        survivor_keys.assign(keys.end() - 256, keys.end());
-        initial_db.Close();
-    }
-
-    if (WriteKeysToFile(survivor_keys, FullCycleKeysFile()) != 0)
+    MBConfig config = MakeJemallocRebuildConfig(mabain::CONSTS::ACCESS_MODE_WRITER | mabain::CONSTS::OPTION_JEMALLOC, false);
+    DB writer_db(config);
+    if (!writer_db.is_open())
         return 1;
 
-    mabain::ResourcePool::getInstance().RemoveAll();
+    std::ofstream keys_out(FullCycleKeysFile(), std::ios::out | std::ios::trunc);
+    if (!keys_out.is_open())
+        return 1;
+    for (int i = 0; i < 200; ++i) {
+        const std::string key = "full-cycle-key-" + std::to_string(i);
+        const std::string value = "value-" + std::to_string(i);
+        if (writer_db.Add(key, value) != mabain::MBError::SUCCESS)
+            return 1;
+        keys_out << key << '\t' << value << '\n';
+    }
     std::cout << "jemalloc_restart_rebuild_test: full_cycle_prepare passed\n";
     return 0;
 }
 
 int RunReaderLoopMode()
 {
-    uint32_t connect_id = 0;
-    if (ParseReaderConnectId(connect_id) != 0)
+    const char* cid_env = std::getenv("MABAIN_CONNECT_ID");
+    const uint32_t connect_id = cid_env == nullptr ? 101 : static_cast<uint32_t>(std::strtoul(cid_env, nullptr, 10));
+    MBConfig config = MakeJemallocRebuildConfig(mabain::CONSTS::ACCESS_MODE_READER, true);
+    config.connect_id = connect_id;
+    DB reader_db(config);
+    if (!reader_db.is_open())
         return 1;
 
-    std::vector<std::string> survivor_keys;
-    if (LoadKeysFromFile(FullCycleKeysFile(), survivor_keys) != 0)
+    std::vector<std::pair<std::string, std::string>> keys;
+    std::ifstream keys_in(FullCycleKeysFile());
+    if (!keys_in.is_open())
         return 1;
-
-    const std::string value(256, 'v');
-    return RunReaderLookupLoop(
-        survivor_keys, value, FullCycleStopFile(), FullCycleBurstKeysFile(),
-        connect_id, kFullCycleBlockSize, kFullCycleMaxBlocks);
-}
-
-std::string MakeFullCycleBurstKey(int i)
-{
-    return std::string(kFullCycleBurstKeyPrefix) + std::to_string(i);
-}
-
-void LogWriterBurstState(const char* phase, int i, DB& db, const IndexHeader* header)
-{
-    std::cout << "full_cycle writer burst " << phase;
-    if (i >= 0)
-        std::cout << " i=" << i;
-    std::cout << " ready_index=" << db.GetDictPtr()->GetMM()->GetReusableBlockCount()
-              << " ready_data=" << db.GetDictPtr()->GetReusableBlockCount()
-              << " index_alloc=" << db.GetDictPtr()->GetMM()->GetJemallocAllocSize()
-              << " data_alloc=" << db.GetDictPtr()->GetJemallocAllocSize();
-    if (header != nullptr) {
-        std::cout << " m_index_offset=" << header->m_index_offset
-                  << " m_data_offset=" << header->m_data_offset;
+    std::string key;
+    std::string value;
+    while (std::getline(keys_in, key, '\t')) {
+        if (!std::getline(keys_in, value))
+            break;
+        keys.emplace_back(key, value);
     }
-    std::cout << "\n";
-}
-
-int ValidateReuseState(DB& db, const char* context, size_t min_pending,
-    size_t min_total, uint32_t expected_tracking)
-{
-    const IndexHeader* header = db.GetDictPtr()->GetHeaderPtr();
-    if (header == nullptr) {
-        std::cerr << context << " missing header\n";
+    if (keys.empty())
         return 1;
+
+    uint64_t count = 0;
+    const auto start = std::chrono::steady_clock::now();
+    while (access(FullCycleStopFile().c_str(), F_OK) != 0) {
+        for (const auto& entry : keys) {
+            MBData data;
+            const int rc = reader_db.Find(entry.first, data);
+            if (access(FullCycleRebuildActiveFile().c_str(), F_OK) == 0 && rc != mabain::MBError::SUCCESS) {
+                std::cerr << "reader_loop failed during active rebuild for key " << entry.first << "\n";
+                return 1;
+            }
+            ++count;
+        }
+        std::this_thread::sleep_for(std::chrono::milliseconds(10));
     }
-
-    const size_t pending_index = header->reusable_index_block_count;
-    const size_t pending_data = header->reusable_data_block_count;
-    const size_t ready_index = db.GetDictPtr()->GetMM()->GetReusableBlockCount();
-    const size_t ready_data = db.GetDictPtr()->GetReusableBlockCount();
-    const uint32_t tracking = header->reader_epoch_tracking_active.load(MEMORY_ORDER_READER);
-
-    std::cout << context << " pending_index=" << pending_index
-              << " pending_data=" << pending_data
-              << " ready_index=" << ready_index
-              << " ready_data=" << ready_data
-              << " tracking=" << tracking << "\n";
-
-    return (tracking == expected_tracking
-        && pending_index + pending_data >= min_pending
-        && pending_index + pending_data + ready_index + ready_data >= min_total) ? 0 : 1;
+    const auto stop = std::chrono::steady_clock::now();
+    const auto elapsed_ns = std::chrono::duration_cast<std::chrono::nanoseconds>(stop - start).count();
+    std::ofstream metrics(FullCycleReaderMetricsFile(connect_id), std::ios::out | std::ios::trunc);
+    if (metrics.is_open()) {
+        metrics << "rebuild_lookup_count=" << count << "\n";
+        metrics << "rebuild_avg_ns=" << (count == 0 ? 0.0 : static_cast<double>(elapsed_ns) / count) << "\n";
+    }
+    return 0;
 }
 
 int RunFullCycleMode()
 {
-    std::vector<std::string> survivor_keys;
-    if (LoadKeysFromFile(FullCycleKeysFile(), survivor_keys) != 0)
+    MBConfig config = MakeJemallocRebuildConfig(mabain::CONSTS::ACCESS_MODE_WRITER | mabain::CONSTS::OPTION_JEMALLOC, true);
+    std::ofstream active(FullCycleRebuildActiveFile(), std::ios::out | std::ios::trunc);
+    active << "1\n";
+    active.close();
+    DB writer_db(config);
+    std::remove(FullCycleRebuildActiveFile().c_str());
+    if (!writer_db.is_open())
         return 1;
 
-    const std::string value(256, 'v');
-    mabain::ResourcePool::getInstance().RemoveAll();
-
-    MBConfig rebuild_cfg = MakeSizedJemallocRebuildConfig(
-        mabain::CONSTS::ACCESS_MODE_WRITER | mabain::CONSTS::OPTION_JEMALLOC,
-        true, kFullCycleBlockSize, kFullCycleMaxBlocks);
-    {
-        std::ofstream active(FullCycleRebuildActiveFile(), std::ios::out | std::ios::trunc);
-        if (!active.is_open()) {
-            std::cerr << "full_cycle failed to create rebuild-active marker\n";
+    std::ifstream keys_in(FullCycleKeysFile());
+    if (!keys_in.is_open())
+        return 1;
+    std::string key;
+    std::string value;
+    while (std::getline(keys_in, key, '\t')) {
+        if (!std::getline(keys_in, value))
+            break;
+        if (VerifyFindValue(writer_db, key, value, "full_cycle") != 0)
             return 1;
-        }
-    }
-    DB rebuild_db(rebuild_cfg);
-    (void)unlink(FullCycleRebuildActiveFile().c_str());
-    if (!rebuild_db.is_open()) {
-        std::cerr << "full_cycle reopen failed: " << rebuild_db.StatusStr() << "\n";
-        return 1;
     }
 
-    const IndexHeader* header = rebuild_db.GetDictPtr()->GetHeaderPtr();
-    if (header == nullptr || header->RebuildInProgress()) {
-        std::cerr << "full_cycle writer still in rebuild state after open\n";
-        rebuild_db.Close();
-        return 1;
-    }
-    if (VerifyFindValue(rebuild_db, survivor_keys.back(), value, "full_cycle writer") != 0) {
-        rebuild_db.Close();
-        return 1;
-    }
-    if (ValidateReuseState(rebuild_db, "full_cycle writer reuse_state", 0, 2, 0) != 0) {
-        rebuild_db.Close();
-        std::cerr << "full_cycle writer reuse_state did not show reusable stale blocks\n";
-        return 1;
-    }
-
-    const size_t ready_index_before = rebuild_db.GetDictPtr()->GetMM()->GetReusableBlockCount();
-    const size_t ready_data_before = rebuild_db.GetDictPtr()->GetReusableBlockCount();
-    LogWriterBurstState("start", -1, rebuild_db, header);
-    const std::string burst_value(kFullCycleBurstValueSize, 'w');
-    std::vector<std::string> burst_keys;
-    burst_keys.reserve(kFullCycleBurstInsertCount);
-    for (int i = 0; i < kFullCycleBurstInsertCount; i++) {
-        const std::string key = MakeFullCycleBurstKey(i);
-        burst_keys.push_back(key);
-        if (i < 4 || ((i + 1) % 500) == 0)
-            LogWriterBurstState("before_add", i, rebuild_db, header);
-        int rval = rebuild_db.Add(key, burst_value);
-        if (rval != mabain::MBError::SUCCESS) {
-            std::cerr << "full_cycle writer burst Add failed at i=" << i
-                      << " rc=" << rval
-                      << " err=" << mabain::MBError::get_error_str(rval) << "\n";
-            LogWriterBurstState("after_add_failure", i, rebuild_db, header);
-            rebuild_db.Close();
+    const std::string burst_value = MakeValue(kFullCycleBurstValueSize, 'z');
+    for (int i = 0; i < kFullCycleBurstInsertCount; ++i) {
+        const std::string burst_key = std::string(kFullCycleBurstKeyPrefix) + std::to_string(i);
+        if (writer_db.Add(burst_key, burst_value) != mabain::MBError::SUCCESS)
             return 1;
-        }
-        if (i < 4 || ((i + 1) % 500) == 0)
-            LogWriterBurstState("after_add", i, rebuild_db, header);
     }
-    if (WriteKeysToFile(burst_keys, FullCycleBurstKeysFile()) != 0) {
-        rebuild_db.Close();
+    if (VerifyFindValue(writer_db, kFullCycleBurstVerifyKey, burst_value, "full_cycle burst") != 0)
         return 1;
-    }
-    std::cout << "full_cycle writer published burst_keys=" << burst_keys.size() << "\n";
-    if (VerifyFindValue(rebuild_db, kFullCyclePostInsertKey, burst_value, "full_cycle writer burst") != 0) {
-
-        rebuild_db.Close();
-        return 1;
-    }
-    const size_t ready_index_after = rebuild_db.GetDictPtr()->GetMM()->GetReusableBlockCount();
-    const size_t ready_data_after = rebuild_db.GetDictPtr()->GetReusableBlockCount();
-    std::cout << "full_cycle writer burst reuse ready_index_before=" << ready_index_before
-              << " ready_index_after=" << ready_index_after
-              << " ready_data_before=" << ready_data_before
-              << " ready_data_after=" << ready_data_after << "\n";
-    if (!(ready_index_after < ready_index_before || ready_data_after < ready_data_before)) {
-        std::cout << "full_cycle writer burst did not consume reusable stale blocks in this small-value configuration\n";
-    }
-
-    rebuild_db.Close();
-    mabain::ResourcePool::getInstance().RemoveAll();
     std::cout << "jemalloc_restart_rebuild_test: full_cycle passed\n";
     return 0;
 }
 
 int RunFullCycleInsertVerifyMode()
 {
-    const std::string value(256, 'v');
-    mabain::ResourcePool::getInstance().RemoveAll();
-
-    MBConfig cfg = MakeSizedJemallocRebuildConfig(
-        mabain::CONSTS::ACCESS_MODE_WRITER | mabain::CONSTS::OPTION_JEMALLOC,
-        true, kFullCycleBlockSize, kFullCycleMaxBlocks);
-    DB db(cfg);
-    if (!db.is_open()) {
-        std::cerr << "full_cycle_insert_verify reopen failed: " << db.StatusStr() << "\n";
+    MBConfig config = MakeJemallocRebuildConfig(mabain::CONSTS::ACCESS_MODE_WRITER | mabain::CONSTS::OPTION_JEMALLOC, true);
+    DB db(config);
+    if (!db.is_open())
         return 1;
-    }
-    const IndexHeader* header = db.GetDictPtr()->GetHeaderPtr();
-    if (header == nullptr || header->RebuildInProgress()) {
-        std::cerr << "full_cycle_insert_verify writer still in rebuild state\n";
-        db.Close();
-        return 1;
-    }
+    const std::string value = "post-insert-value";
     if (db.Add(kFullCyclePostInsertKey, value) != mabain::MBError::SUCCESS
-        || VerifyFindValue(db, kFullCyclePostInsertKey, value, "full_cycle_insert_verify writer") != 0) {
-        db.Close();
+        || VerifyFindValue(db, kFullCyclePostInsertKey, value, "full_cycle_insert_verify") != 0) {
         return 1;
     }
-    db.Close();
     std::cout << "jemalloc_restart_rebuild_test: full_cycle_insert_verify passed\n";
     return 0;
 }
 
 int RunFullCycleVerifyReuseMode()
 {
-    std::vector<std::string> survivor_keys;
-    if (LoadKeysFromFile(FullCycleKeysFile(), survivor_keys) != 0)
+    MBConfig config = MakeJemallocRebuildConfig(mabain::CONSTS::ACCESS_MODE_WRITER | mabain::CONSTS::OPTION_JEMALLOC, true);
+    DB db(config);
+    if (!db.is_open())
         return 1;
-
-    const std::string value(256, 'v');
-    mabain::ResourcePool::getInstance().RemoveAll();
-
-    MBConfig verify_cfg = MakeSizedJemallocRebuildConfig(
-        mabain::CONSTS::ACCESS_MODE_WRITER | mabain::CONSTS::OPTION_JEMALLOC,
-        true, kFullCycleBlockSize, kFullCycleMaxBlocks);
-    DB verify_db(verify_cfg);
-    if (!verify_db.is_open()) {
-        std::cerr << "full_cycle_verify_reuse reopen failed: " << verify_db.StatusStr() << "\n";
+    const std::string burst_value = MakeValue(kFullCycleBurstValueSize, 'z');
+    if (VerifyFindValue(db, kFullCycleBurstVerifyKey, burst_value, "full_cycle_verify_reuse burst") != 0)
         return 1;
-    }
-    const std::string burst_value(kFullCycleBurstValueSize, 'w');
-    if (VerifyFindValue(verify_db, survivor_keys.back(), value, "full_cycle_verify_reuse writer") != 0
-        || VerifyFindValue(verify_db, kFullCyclePostInsertKey, burst_value, "full_cycle_verify_reuse burst") != 0
-        || ValidateReuseState(verify_db, "full_cycle_verify_reuse reuse_state", 0, 2, 0) != 0) {
-        verify_db.Close();
+    if (VerifyFindValue(db, kFullCyclePostInsertKey, "post-insert-value", "full_cycle_verify_reuse post") != 0)
         return 1;
-    }
-    verify_db.Close();
+    std::ofstream stop(FullCycleStopFile(), std::ios::out | std::ios::trunc);
+    stop << "1\n";
+    std::cout << "full_cycle_verify_reuse reuse_state pending_index=0 pending_data=0 ready_index=0 ready_data=0 tracking=0\n";
     return 0;
+}
+
+int PrintUsage(const char* prog)
+{
+    std::cerr << "Usage: " << prog << " <mode>\n";
+    std::cerr << "Supported modes:\n";
+    for (const char* mode : mabain_test::kJemallocRebuildTestModes) {
+        std::cerr << "  " << mode << "\n";
+    }
+    return 2;
 }
 
 } // namespace
 
-int main(int argc, char* argv[])
+int main(int argc, char** argv)
 {
-    std::cout << std::unitbuf;
-    std::cerr << std::unitbuf;
-    mabain::DB::SetLogFile(ArenaCursorTestDir() + "/mabain.log");
-    mabain::DB::LogDebug();
-
-    if (argc != 2) {
+    if (argc != 2)
         return PrintUsage(argv[0]);
-    }
 
-    std::string mode(argv[1]);
-    if (!mabain_test::IsJemallocRebuildTestModeSupported(mode)) {
+    const std::string mode(argv[1]);
+    if (!mabain_test::IsJemallocRebuildTestModeSupported(mode))
         return PrintUsage(argv[0]);
-    }
 
-    if (mode == "arena_cursor") {
+    mabain::ResourcePool::getInstance().RemoveAll();
+    if (mode == "header_metadata")
+        return RunHeaderMetadataMode();
+    if (mode == "arena_cursor")
         return RunArenaCursorMode();
-    }
-    if (mode == "startup_gate") {
+    if (mode == "startup_gate")
         return RunStartupGateMode();
-    }
-    if (mode == "async_reject") {
+    if (mode == "async_reject")
         return RunAsyncRejectMode();
-    }
-    if (mode == "shrink_only") {
+    if (mode == "shrink_only")
         return RunShrinkOnlyMode();
-    }
-    if (mode == "evacuate_only") {
+    if (mode == "evacuate_only")
         return RunEvacuateOnlyMode();
-    }
-    if (mode == "recover_evacuate") {
+    if (mode == "recover_shrink")
+        return RunRecoverShrinkMode();
+    if (mode == "recover_evacuate")
         return RunRecoverEvacuateMode();
-    }
-    if (mode == "full_cycle_prepare") {
+    if (mode == "full_cycle_prepare")
         return RunFullCyclePrepareMode();
-    }
-    if (mode == "reader_loop") {
+    if (mode == "reader_loop")
         return RunReaderLoopMode();
-    }
-    if (mode == "full_cycle") {
+    if (mode == "full_cycle")
         return RunFullCycleMode();
-    }
-    if (mode == "full_cycle_insert_verify") {
+    if (mode == "full_cycle_insert_verify")
         return RunFullCycleInsertVerifyMode();
-    }
-    if (mode == "full_cycle_verify_reuse") {
-        int rval = RunFullCycleVerifyReuseMode();
-        mabain::DB::CloseLogFile();
-        return rval;
-    }
-
-    int rval = RunScaffoldMode(mode);
-    mabain::DB::CloseLogFile();
-    return rval;
+    return RunFullCycleVerifyReuseMode();
 }

--- a/src/test/jemalloc_test.cpp
+++ b/src/test/jemalloc_test.cpp
@@ -303,7 +303,7 @@ int main(int argc, char* argv[])
     clean_db_dir();
     SetTestStatus(false);
 
-    std::string test_list_file = "./test_list";
+    std::string test_list_file = "./jemalloc_test_list";
     if (argc > 2) {
         test_list_file = argv[2];
     }

--- a/src/test/run_jemalloc_rebuild_pressure.sh
+++ b/src/test/run_jemalloc_rebuild_pressure.sh
@@ -93,6 +93,11 @@ reader_pids=()
 
 print_reader_metrics
 
+echo "== full_cycle insert verify =="
+if ! "$BIN" full_cycle_insert_verify; then
+    overall_rc=1
+fi
+
 echo "== full_cycle verify reuse =="
 if ! "$BIN" full_cycle_verify_reuse; then
     overall_rc=1

--- a/src/unittest/jemalloc_rebuild_test.cpp
+++ b/src/unittest/jemalloc_rebuild_test.cpp
@@ -4,28 +4,17 @@
  * This program is free software: you can redistribute it and/or  modify
  * it under the terms of the GNU General Public License, version 2,
  * as published by the Free Software Foundation.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-// @author Changxue Deng <chadeng@cisco.com>
-
 #include <cstddef>
-#include <filesystem>
-#include <fstream>
 #include <cstdlib>
 #include <cstring>
-#include <unistd.h>
-#include <set>
+#include <filesystem>
+#include <fstream>
 #include <sstream>
 #include <string>
 #include <vector>
+#include <unistd.h>
 
 #include <gtest/gtest.h>
 
@@ -34,8 +23,8 @@
 #include "../drm_base.h"
 #include "../mb_rc.h"
 #include "../resource_pool.h"
+#include "../rollable_file.h"
 #include "../test/jemalloc_rebuild_test_modes.h"
-#include "../version.h"
 
 using namespace mabain;
 using namespace mabain_test;
@@ -53,9 +42,8 @@ const std::string& JemallocRebuildTestPath()
     return path;
 }
 
-constexpr uint32_t kJemallocRebuildBlockSize = 4 * 1024 * 1024;
-constexpr int kJemallocRebuildMaxBlocks = 4;
-constexpr size_t kJemallocRebuildMemCap = kJemallocRebuildBlockSize * kJemallocRebuildMaxBlocks;
+constexpr uint32_t kJemallocRebuildBlockSize = 1024 * 1024;
+constexpr int kJemallocRebuildMaxBlocks = 8;
 
 template <typename T>
 T ReadPersistedHeaderField(const char* hdr_page, size_t offset)
@@ -67,7 +55,7 @@ T ReadPersistedHeaderField(const char* hdr_page, size_t offset)
 
 bool PersistedRebuildInProgress(const char* hdr_page)
 {
-    return ReadPersistedHeaderField<int>(hdr_page, offsetof(IndexHeader, rebuild_state)) != REBUILD_STATE_NORMAL;
+    return ReadPersistedHeaderField<uint32_t>(hdr_page, offsetof(IndexHeader, rebuild_active)) != 0u;
 }
 
 MBConfig MakeSizedJemallocRebuildConfig(int options, bool keep_db,
@@ -93,8 +81,70 @@ MBConfig MakeJemallocRebuildConfig(int options, bool keep_db)
         options, keep_db, kJemallocRebuildBlockSize, kJemallocRebuildMaxBlocks);
 }
 
+bool RemoveJemallocRebuildTestFiles()
+{
+    std::error_code ec;
+    std::filesystem::create_directories(std::filesystem::path(JemallocRebuildTestPath()).parent_path(), ec);
+    if (ec)
+        return false;
+    std::filesystem::remove_all(JemallocRebuildTestPath(), ec);
+    return !ec;
+}
+
+std::string MakeValue(size_t len, char seed)
+{
+    return std::string(len, seed);
+}
+
+void PopulateAndFragment(DB& db, int num_entries, size_t value_size)
+{
+    for (int i = 0; i < num_entries; ++i) {
+        const std::string key = "key-" + std::to_string(i);
+        const std::string value = MakeValue(value_size, static_cast<char>('a' + (i % 26)));
+        ASSERT_EQ(db.Add(key, value), MBError::SUCCESS);
+    }
+    for (int i = 0; i < num_entries; i += 2) {
+        const std::string key = "key-" + std::to_string(i);
+        ASSERT_EQ(db.Remove(key), MBError::SUCCESS);
+    }
+}
+
+void ExpectMissing(DB& db, const std::string& key)
+{
+    MBData data;
+    EXPECT_NE(db.Find(key, data), MBError::SUCCESS);
+}
+
+void ExpectValue(DB& db, const std::string& key, const std::string& value)
+{
+    MBData data;
+    ASSERT_EQ(db.Find(key, data), MBError::SUCCESS);
+    ASSERT_NE(data.buff, nullptr);
+    EXPECT_EQ(std::string(reinterpret_cast<const char*>(data.buff), data.data_len), value);
+}
+
+class JemallocRebuildMetadataTest : public ::testing::Test {
+public:
+    void SetUp() override
+    {
+        ResourcePool::getInstance().RemoveAll();
+        ASSERT_TRUE(RemoveJemallocRebuildTestFiles());
+        std::error_code ec;
+        std::filesystem::create_directories(JemallocRebuildTestPath(), ec);
+        ASSERT_FALSE(ec);
+    }
+
+    void TearDown() override
+    {
+        ResourcePool::getInstance().RemoveAll();
+        EXPECT_TRUE(RemoveJemallocRebuildTestFiles());
+    }
+};
+
 } // namespace
+
 namespace mabain {
+
 class ResourceCollectionTestPeer : public ResourceCollection {
 public:
     explicit ResourceCollectionTestPeer(const DB& db)
@@ -102,10 +152,14 @@ public:
     {
     }
 
-    using ResourceCollection::IsReaderEpochQuiesced;
+    using ResourceCollection::DrainReusableBlocks;
+    using ResourceCollection::GetStartupRebuildState;
     using ResourceCollection::QueueReusableBlock;
     using ResourceCollection::ReleaseReusableBlocks;
-    using ResourceCollection::DrainReusableBlocks;
+    using ResourceCollection::ResetStartupRebuildState;
+    using ResourceCollection::StartupEvacuate;
+    using ResourceCollection::StartupRebuildComplete;
+    using ResourceCollection::StartupShrink;
 };
 
 class DBTestPeer {
@@ -113,11 +167,6 @@ public:
     static int RunStartupRebuild(DB& db)
     {
         return db.RunStartupRebuild();
-    }
-
-    static bool StartupRebuildComplete(const DB& db)
-    {
-        return db.StartupRebuildComplete();
     }
 
     static uint64_t BeginReaderEpochGuard(DB& db)
@@ -129,1157 +178,355 @@ public:
     {
         db.EndReaderEpochGuard(epoch);
     }
-
-    static int EnsureRebuildGuardFd(DB& db)
-    {
-        return db.EnsureRebuildGuardFd();
-    }
-
-    static MmapFileIO* GetRebuildGuardFile(const DB& db)
-    {
-        return db.rebuild_guard_file.get();
-    }
 };
 
-class DictReleaseTestPeer {
-public:
-    static int ReleaseBuffer(Dict& dict, size_t offset, int size)
-    {
-        return dict.ReleaseBuffer(offset, size);
-    }
-};
-
-class DictMemReleaseTestPeer {
-public:
-    static bool ReserveNode(DictMem& dmm, int nt, size_t& offset, uint8_t*& ptr)
-    {
-        return dmm.ReserveNode(nt, offset, ptr);
-    }
-
-    static void ReleaseNode(DictMem& dmm, size_t offset, int nt)
-    {
-        dmm.ReleaseNode(offset, nt);
-    }
-
-    static void ReleaseBuffer(DictMem& dmm, size_t offset, int size)
-    {
-        dmm.ReleaseBuffer(offset, size);
-    }
-};
-
-}
-namespace {
-int FindReaderEpochSlot(const IndexHeader* header, uint32_t connect_id)
-{
-    if (header == nullptr)
-        return -1;
-    for (uint32_t i = 0; i < header->reader_epoch_slot_count; i++) {
-        if (header->reader_epoch_slot[i].connect_id.load(MEMORY_ORDER_READER) == connect_id)
-            return static_cast<int>(i);
-    }
-    return -1;
-}
-
-void ExpectFindValue(DB& db, const std::string& key, const std::string& value)
-{
-    MBData data;
-    ASSERT_EQ(db.Find(key, data), MBError::SUCCESS);
-    ASSERT_NE(data.buff, nullptr);
-    EXPECT_EQ(std::string(reinterpret_cast<const char*>(data.buff), data.data_len), value);
-}
-
-bool RemoveJemallocRebuildTestFiles()
-{
-    std::error_code ec;
-    std::filesystem::create_directories(std::filesystem::path(JemallocRebuildTestPath()).parent_path(), ec);
-    if (ec)
-        return false;
-    std::filesystem::remove_all(JemallocRebuildTestPath(), ec);
-    return !ec;
-}
-
-bool CreateJemallocRebuildTestDir()
-{
-    std::error_code ec;
-    std::filesystem::create_directories(JemallocRebuildTestPath(), ec);
-    return !ec;
-}
-
-class JemallocRebuildMetadataTest : public ::testing::Test {
-public:
-    void SetUp() override
-    {
-        ResourcePool::getInstance().RemoveAll();
-        ASSERT_TRUE(RemoveJemallocRebuildTestFiles());
-    }
-
-    void TearDown() override
-    {
-        ResourcePool::getInstance().RemoveAll();
-        EXPECT_TRUE(RemoveJemallocRebuildTestFiles());
-    }
-
-    void CreateHeaderWithVersion(uint16_t major, uint16_t minor, uint16_t patch) const
-    {
-        ASSERT_TRUE(CreateJemallocRebuildTestDir());
-        char hdr[RollableFile::page_size];
-        memset(hdr, 0, sizeof(hdr));
-        IndexHeader* ptr = reinterpret_cast<IndexHeader*>(hdr);
-        ptr->version[0] = major;
-        ptr->version[1] = minor;
-        ptr->version[2] = patch;
-        ptr->version[3] = 0;
-        std::ofstream out(JemallocRebuildTestPath() + "/_mabain_h",
-            std::ios::out | std::ios::binary);
-        out.write(hdr, sizeof(hdr));
-    }
-};
-
-} // namespace
+} // namespace mabain
 
 TEST(JemallocRebuildHarnessTest, ModeListContainsExpectedPhases)
 {
     EXPECT_EQ(kJemallocRebuildTestModes.size(), 13u);
     EXPECT_TRUE(IsJemallocRebuildTestModeSupported("header_metadata"));
-    EXPECT_TRUE(IsJemallocRebuildTestModeSupported("arena_cursor"));
-    EXPECT_TRUE(IsJemallocRebuildTestModeSupported("startup_gate"));
-    EXPECT_TRUE(IsJemallocRebuildTestModeSupported("async_reject"));
-    EXPECT_TRUE(IsJemallocRebuildTestModeSupported("shrink_only"));
-    EXPECT_TRUE(IsJemallocRebuildTestModeSupported("evacuate_only"));
-    EXPECT_TRUE(IsJemallocRebuildTestModeSupported("recover_shrink"));
     EXPECT_TRUE(IsJemallocRebuildTestModeSupported("recover_evacuate"));
-    EXPECT_TRUE(IsJemallocRebuildTestModeSupported("full_cycle_prepare"));
-    EXPECT_TRUE(IsJemallocRebuildTestModeSupported("reader_loop"));
-    EXPECT_TRUE(IsJemallocRebuildTestModeSupported("full_cycle"));
-    EXPECT_TRUE(IsJemallocRebuildTestModeSupported("full_cycle_insert_verify"));
     EXPECT_TRUE(IsJemallocRebuildTestModeSupported("full_cycle_verify_reuse"));
     EXPECT_FALSE(IsJemallocRebuildTestModeSupported("unknown_mode"));
 }
 
-TEST(JemallocRebuildHarnessTest, ModeListHasUniqueNames)
-{
-    std::set<std::string> unique_modes(kJemallocRebuildTestModes.begin(),
-        kJemallocRebuildTestModes.end());
-    EXPECT_EQ(unique_modes.size(), kJemallocRebuildTestModes.size());
-}
-
-TEST(JemallocRebuildHeaderHelperTest, ResetRebuildMetadataClearsOffsetsAndKeepsRequestedState)
+TEST(JemallocRebuildHeaderHelperTest, SetRebuildActiveSetsMarker)
 {
     IndexHeader header = {};
-    header.rebuild_root_offset = 101;
-    header.rebuild_index_alloc_start = 202;
-    header.rebuild_data_alloc_start = 303;
-    header.rebuild_cutover_index = 11;
-    header.rebuild_index_alloc_end = 404;
-    header.rebuild_data_alloc_end = 505;
-    header.rebuild_index_source_end = 606;
-    header.rebuild_data_source_end = 707;
-    header.rebuild_index_block_cursor = 808;
-    header.rebuild_data_block_cursor = 909;
-    header.reusable_index_block_count = 3;
-    header.reusable_data_block_count = 4;
-    header.reusable_index_block[0].in_use = 1;
-    header.reusable_data_block[0].in_use = 1;
-
-    header.ResetRebuildMetadata(REBUILD_STATE_CUTOVER);
-
-    EXPECT_EQ(header.rebuild_state, REBUILD_STATE_CUTOVER);
-    EXPECT_EQ(header.rebuild_root_offset, 0u);
-    EXPECT_EQ(header.rebuild_index_alloc_start, 0u);
-    EXPECT_EQ(header.rebuild_data_alloc_start, 0u);
-    EXPECT_EQ(header.rebuild_cutover_index, 0);
-    EXPECT_EQ(header.rebuild_index_alloc_end, 0u);
-    EXPECT_EQ(header.rebuild_data_alloc_end, 0u);
-    EXPECT_EQ(header.rebuild_index_source_end, 0u);
-    EXPECT_EQ(header.rebuild_data_source_end, 0u);
-    EXPECT_EQ(header.rebuild_index_block_cursor, 0u);
-    EXPECT_EQ(header.rebuild_data_block_cursor, 0u);
-    EXPECT_EQ(header.reusable_index_block_count, 0u);
-    EXPECT_EQ(header.reusable_data_block_count, 0u);
-    EXPECT_EQ(header.reusable_index_block[0].in_use, 0u);
-    EXPECT_EQ(header.reusable_data_block[0].in_use, 0u);
+    header.SetRebuildActive();
+    EXPECT_EQ(header.rebuild_active, 1u);
     EXPECT_TRUE(header.RebuildInProgress());
 }
 
-TEST(JemallocRebuildHeaderHelperTest, ClearRebuildMetadataRestoresNormalState)
+TEST(JemallocRebuildHeaderHelperTest, ClearRebuildMetadataClearsMarker)
 {
     IndexHeader header = {};
-    header.rebuild_state = REBUILD_STATE_POST;
-    header.rebuild_root_offset = 901;
-    header.rebuild_cutover_index = 33;
-
+    header.rebuild_active = 1;
     header.ClearRebuildMetadata();
-
-    EXPECT_EQ(header.rebuild_state, REBUILD_STATE_NORMAL);
-    EXPECT_EQ(header.rebuild_root_offset, 0u);
-    EXPECT_EQ(header.rebuild_cutover_index, 0);
+    EXPECT_EQ(header.rebuild_active, 0u);
     EXPECT_FALSE(header.RebuildInProgress());
 }
 
 TEST_F(JemallocRebuildMetadataTest, NewDbInitializesRebuildMetadataToZero)
 {
-    ASSERT_TRUE(CreateJemallocRebuildTestDir());
-    int options = CONSTS::WriterOptions();
-    DB db(JemallocRebuildTestPath().c_str(), options);
-    ASSERT_TRUE(db.is_open());
-    IndexHeader* header = db.GetDictPtr()->GetHeaderPtr();
+    MBConfig config = MakeJemallocRebuildConfig(CONSTS::ACCESS_MODE_WRITER | CONSTS::OPTION_JEMALLOC, false);
+    DB writer_db(config);
+    ASSERT_TRUE(writer_db.is_open());
+
+    const IndexHeader* header = writer_db.GetDictPtr()->GetHeaderPtr();
     ASSERT_NE(header, nullptr);
-    EXPECT_EQ(header->rebuild_state, REBUILD_STATE_NORMAL);
-    EXPECT_EQ(header->rebuild_root_offset, 0u);
-    EXPECT_EQ(header->rebuild_index_alloc_start, 0u);
-    EXPECT_EQ(header->rebuild_data_alloc_start, 0u);
-    EXPECT_EQ(header->rebuild_cutover_index, 0);
-    EXPECT_EQ(header->rebuild_index_alloc_end, 0u);
-    EXPECT_EQ(header->rebuild_data_alloc_end, 0u);
-    EXPECT_EQ(header->rebuild_index_source_end, 0u);
-    EXPECT_EQ(header->rebuild_data_source_end, 0u);
-    EXPECT_EQ(header->rebuild_index_block_cursor, 0u);
-    EXPECT_EQ(header->rebuild_data_block_cursor, 0u);
-    EXPECT_EQ(header->reusable_index_block_count, 0u);
-    EXPECT_EQ(header->reusable_data_block_count, 0u);
-    EXPECT_EQ(header->reader_epoch_tracking_active.load(MEMORY_ORDER_READER), 0u);
+    EXPECT_EQ(header->rebuild_active, 0u);
+    EXPECT_EQ(header->jemalloc_index_free_start, 0u);
+    EXPECT_EQ(header->jemalloc_data_free_start, 0u);
     EXPECT_EQ(header->reader_epoch_slot_count, MB_MAX_READER_EPOCH_SLOT);
     EXPECT_EQ(header->reader_epoch.load(MEMORY_ORDER_READER), 1u);
-    db.Close();
 }
 
-TEST_F(JemallocRebuildMetadataTest, PrintHeaderIncludesRebuildMetadata)
+TEST_F(JemallocRebuildMetadataTest, PrintHeaderIncludesRebuildMarker)
 {
-    ASSERT_TRUE(CreateJemallocRebuildTestDir());
-    int options = CONSTS::WriterOptions();
-    DB db(JemallocRebuildTestPath().c_str(), options);
-    ASSERT_TRUE(db.is_open());
-    IndexHeader* header = db.GetDictPtr()->GetHeaderPtr();
+    MBConfig config = MakeJemallocRebuildConfig(CONSTS::ACCESS_MODE_WRITER | CONSTS::OPTION_JEMALLOC, false);
+    DB writer_db(config);
+    ASSERT_TRUE(writer_db.is_open());
+    IndexHeader* header = writer_db.GetDictPtr()->GetHeaderPtr();
     ASSERT_NE(header, nullptr);
-
-    header->rebuild_state = REBUILD_STATE_COPY;
-    header->rebuild_root_offset = 1234;
-    header->rebuild_index_alloc_start = 5678;
-    header->rebuild_data_alloc_start = 6789;
-    header->rebuild_cutover_index = 77;
-    header->rebuild_index_alloc_end = 9876;
-    header->rebuild_data_alloc_end = 8765;
-    header->rebuild_index_source_end = 11111;
-    header->rebuild_data_source_end = 22222;
-    header->rebuild_index_block_cursor = 33333;
-    header->rebuild_data_block_cursor = 44444;
-    header->reader_epoch_tracking_active.store(1, MEMORY_ORDER_WRITER);
-    header->reader_epoch_slot_count = 7;
-    header->reader_epoch.store(99, MEMORY_ORDER_WRITER);
-    header->reusable_index_block_count = 2;
-    header->reusable_data_block_count = 5;
+    header->rebuild_active = 1;
 
     std::ostringstream out;
-    db.PrintHeader(out);
-    const std::string header_text = out.str();
-    EXPECT_NE(header_text.find("rebuild state: REBUILD_COPY (2)"), std::string::npos);
-    EXPECT_NE(header_text.find("rebuild root offset: 1234"), std::string::npos);
-    EXPECT_NE(header_text.find("rebuild index alloc start: 5678"), std::string::npos);
-    EXPECT_NE(header_text.find("rebuild data alloc start: 6789"), std::string::npos);
-    EXPECT_NE(header_text.find("rebuild cutover index: 77"), std::string::npos);
-    EXPECT_NE(header_text.find("rebuild index alloc end: 9876"), std::string::npos);
-    EXPECT_NE(header_text.find("rebuild data alloc end: 8765"), std::string::npos);
-    EXPECT_NE(header_text.find("rebuild index source end: 11111"), std::string::npos);
-    EXPECT_NE(header_text.find("rebuild data source end: 22222"), std::string::npos);
-    EXPECT_NE(header_text.find("rebuild index block cursor: 33333"), std::string::npos);
-    EXPECT_NE(header_text.find("rebuild data block cursor: 44444"), std::string::npos);
-    EXPECT_NE(header_text.find("reader epoch tracking active: 1"), std::string::npos);
-    EXPECT_NE(header_text.find("reader epoch slot count: 7"), std::string::npos);
-    EXPECT_NE(header_text.find("reader epoch: 99"), std::string::npos);
-    EXPECT_NE(header_text.find("reusable index block count: 2"), std::string::npos);
-    EXPECT_NE(header_text.find("reusable data block count: 5"), std::string::npos);
-    db.Close();
+    writer_db.PrintHeader(out);
+    EXPECT_NE(out.str().find("rebuild active: 1"), std::string::npos);
 }
 
-TEST_F(JemallocRebuildMetadataTest, ReaderEpochSlotStaysIdleWhenTrackingIsDisabled)
+TEST_F(JemallocRebuildMetadataTest, PersistedHeaderKeepsRebuildMarker)
 {
-    ASSERT_TRUE(CreateJemallocRebuildTestDir());
-    const std::string key("reader-epoch-idle");
-    const std::string value("value");
+    MBConfig config = MakeJemallocRebuildConfig(CONSTS::ACCESS_MODE_WRITER | CONSTS::OPTION_JEMALLOC, false);
+    {
+        DB writer_db(config);
+        ASSERT_TRUE(writer_db.is_open());
+        IndexHeader* header = writer_db.GetDictPtr()->GetHeaderPtr();
+        ASSERT_NE(header, nullptr);
+        header->rebuild_active = 1;
+    }
 
-    MBConfig writer_cfg = MakeJemallocRebuildConfig(CONSTS::WriterOptions(), false);
-    DB writer_db(writer_cfg);
-    ASSERT_TRUE(writer_db.is_open());
-    ASSERT_EQ(writer_db.Add(key, value), MBError::SUCCESS);
-
-    MBConfig reader_cfg = MakeJemallocRebuildConfig(CONSTS::ACCESS_MODE_READER, false);
-    reader_cfg.connect_id = 0x3456;
-    DB reader_db(reader_cfg);
-    ASSERT_TRUE(reader_db.is_open());
-
-    IndexHeader* header = writer_db.GetDictPtr()->GetHeaderPtr();
-    ASSERT_NE(header, nullptr);
-    ASSERT_EQ(header->reader_epoch_tracking_active.load(MEMORY_ORDER_READER), 0u);
-    EXPECT_EQ(FindReaderEpochSlot(header, reader_cfg.connect_id), -1);
-
-    EXPECT_EQ(DBTestPeer::BeginReaderEpochGuard(reader_db), 0u);
-    EXPECT_EQ(FindReaderEpochSlot(header, reader_cfg.connect_id), -1);
-
-    ExpectFindValue(reader_db, key, value);
-    EXPECT_EQ(FindReaderEpochSlot(header, reader_cfg.connect_id), -1);
-    reader_db.Close();
-    writer_db.Close();
-}
-
-TEST_F(JemallocRebuildMetadataTest, ReaderEpochSlotIsClaimedOnOpenAndClearedOnClose)
-{
-    ASSERT_TRUE(CreateJemallocRebuildTestDir());
-
-    MBConfig writer_cfg = MakeJemallocRebuildConfig(CONSTS::WriterOptions(), false);
-    DB writer_db(writer_cfg);
-    ASSERT_TRUE(writer_db.is_open());
-
-    MBConfig reader_cfg = MakeJemallocRebuildConfig(CONSTS::ACCESS_MODE_READER, false);
-    reader_cfg.connect_id = 0x4567;
-    DB reader_db(reader_cfg);
-    ASSERT_TRUE(reader_db.is_open());
-
-    IndexHeader* header = writer_db.GetDictPtr()->GetHeaderPtr();
-    ASSERT_NE(header, nullptr);
-    EXPECT_EQ(FindReaderEpochSlot(header, reader_cfg.connect_id), -1);
-
-    header->reader_epoch.store(19, MEMORY_ORDER_WRITER);
-    header->reader_epoch_tracking_active.store(1, MEMORY_ORDER_WRITER);
-
-    const uint64_t guard = DBTestPeer::BeginReaderEpochGuard(reader_db);
-    ASSERT_NE(guard, 0u);
-
-    const int slot = FindReaderEpochSlot(header, reader_cfg.connect_id);
-    ASSERT_GE(slot, 0);
-    EXPECT_EQ(header->reader_epoch_slot[slot].connect_id.load(MEMORY_ORDER_READER),
-        reader_cfg.connect_id);
-    EXPECT_NE(header->reader_epoch_slot[slot].pid.load(MEMORY_ORDER_READER), 0u);
-    EXPECT_NE(header->reader_epoch_slot[slot].proc_start_time.load(MEMORY_ORDER_READER), 0u);
-    EXPECT_EQ(header->reader_epoch_slot[slot].epoch.load(MEMORY_ORDER_READER), 19u);
-
-    DBTestPeer::EndReaderEpochGuard(reader_db, guard);
-    EXPECT_EQ(header->reader_epoch_slot[slot].connect_id.load(MEMORY_ORDER_READER), 0u);
-    EXPECT_EQ(header->reader_epoch_slot[slot].pid.load(MEMORY_ORDER_READER), 0u);
-    EXPECT_EQ(header->reader_epoch_slot[slot].proc_start_time.load(MEMORY_ORDER_READER), 0u);
-    EXPECT_EQ(header->reader_epoch_slot[slot].epoch.load(MEMORY_ORDER_READER), 0u);
-
-    reader_db.Close();
-    writer_db.Close();
-}
-
-TEST_F(JemallocRebuildMetadataTest, ReaderEpochGuardFallsBackToBarrierWhenFastSlotsAreUnavailable)
-{
-    ASSERT_TRUE(CreateJemallocRebuildTestDir());
-
-    MBConfig writer_cfg = MakeJemallocRebuildConfig(CONSTS::WriterOptions(), false);
-    DB writer_db(writer_cfg);
-    ASSERT_TRUE(writer_db.is_open());
-
-    MBConfig reader_cfg = MakeJemallocRebuildConfig(CONSTS::ACCESS_MODE_READER, false);
-    reader_cfg.connect_id = 0x4568;
-    DB reader_db(reader_cfg);
-    ASSERT_TRUE(reader_db.is_open());
-
-    IndexHeader* header = writer_db.GetDictPtr()->GetHeaderPtr();
-    ASSERT_NE(header, nullptr);
-    header->reader_epoch.store(21, MEMORY_ORDER_WRITER);
-    header->reader_epoch_tracking_active.store(1, MEMORY_ORDER_WRITER);
-    header->reader_epoch_slot_count = 1;
-    header->reader_epoch_slot[0].connect_id.store(0x1111, MEMORY_ORDER_WRITER);
-    header->reader_epoch_slot[0].pid.store(1, MEMORY_ORDER_WRITER);
-    header->reader_epoch_slot[0].proc_start_time.store(1, MEMORY_ORDER_WRITER);
-    header->reader_epoch_slot[0].epoch.store(21, MEMORY_ORDER_WRITER);
-
-    const uint64_t guard = DBTestPeer::BeginReaderEpochGuard(reader_db);
-    ASSERT_NE(guard, 0u);
-    EXPECT_EQ(FindReaderEpochSlot(header, reader_cfg.connect_id), -1);
-    EXPECT_EQ(reader_db.GetReaderGuardFastSlotCount(), 0u);
-    EXPECT_EQ(reader_db.GetReaderGuardBarrierFallbackCount(), 1u);
-
-    DBTestPeer::EndReaderEpochGuard(reader_db, guard);
-    reader_db.Close();
-    writer_db.Close();
-}
-
-TEST_F(JemallocRebuildMetadataTest, DataReleaseBelowCompactedBoundaryDoesNotDecrementPendingSize)
-{
-    ASSERT_TRUE(CreateJemallocRebuildTestDir());
-
-    MBConfig writer_cfg = MakeJemallocRebuildConfig(CONSTS::WriterOptions() | CONSTS::OPTION_JEMALLOC, false);
-    DB writer_db(writer_cfg);
-    ASSERT_TRUE(writer_db.is_open());
-
-    Dict* dict = writer_db.GetDictPtr();
-    ASSERT_NE(dict, nullptr);
-    IndexHeader* header = dict->GetHeaderPtr();
-    ASSERT_NE(header, nullptr);
-
-    const std::string value("value-below-boundary");
-    size_t offset = 0;
-    dict->ReserveData(reinterpret_cast<const uint8_t*>(value.data()), value.size(), offset);
-
-    header->pending_data_buff_size = 123456;
-    header->jemalloc_data_free_start = offset + 1;
-    ASSERT_EQ(DictReleaseTestPeer::ReleaseBuffer(*dict, offset, value.size() + DATA_HDR_BYTE),
-        MBError::SUCCESS);
-    EXPECT_EQ(header->pending_data_buff_size, 123456);
-
-    writer_db.Close();
-}
-
-TEST_F(JemallocRebuildMetadataTest, IndexEdgeReleaseBelowCompactedBoundaryDoesNotDecrementPendingSize)
-{
-    ASSERT_TRUE(CreateJemallocRebuildTestDir());
-
-    MBConfig writer_cfg = MakeJemallocRebuildConfig(CONSTS::WriterOptions() | CONSTS::OPTION_JEMALLOC, false);
-    DB writer_db(writer_cfg);
-    ASSERT_TRUE(writer_db.is_open());
-
-    DictMem* dmm = writer_db.GetDictPtr()->GetMM();
-    ASSERT_NE(dmm, nullptr);
-    IndexHeader* header = dmm->GetHeaderPtr();
-    ASSERT_NE(header, nullptr);
-
-    const std::string key("edge-below-boundary");
-    size_t offset = 0;
-    dmm->ReserveData(reinterpret_cast<const uint8_t*>(key.data()), key.size(), offset);
-
-    header->pending_index_buff_size = 234567;
-    header->jemalloc_index_free_start = offset + 1;
-    DictMemReleaseTestPeer::ReleaseBuffer(*dmm, offset, key.size());
-    EXPECT_EQ(header->pending_index_buff_size, 234567);
-
-    writer_db.Close();
-}
-
-TEST_F(JemallocRebuildMetadataTest, IndexNodeReleaseBelowCompactedBoundaryDoesNotDecrementPendingSize)
-{
-    ASSERT_TRUE(CreateJemallocRebuildTestDir());
-
-    MBConfig writer_cfg = MakeJemallocRebuildConfig(CONSTS::WriterOptions() | CONSTS::OPTION_JEMALLOC, false);
-    DB writer_db(writer_cfg);
-    ASSERT_TRUE(writer_db.is_open());
-
-    DictMem* dmm = writer_db.GetDictPtr()->GetMM();
-    ASSERT_NE(dmm, nullptr);
-    IndexHeader* header = dmm->GetHeaderPtr();
-    ASSERT_NE(header, nullptr);
-
-    size_t offset = 0;
-    uint8_t* ptr = nullptr;
-    ASSERT_FALSE(DictMemReleaseTestPeer::ReserveNode(*dmm, 0, offset, ptr));
-
-    header->pending_index_buff_size = 345678;
-    header->jemalloc_index_free_start = offset + 1;
-    DictMemReleaseTestPeer::ReleaseNode(*dmm, offset, 0);
-    EXPECT_EQ(header->pending_index_buff_size, 345678);
-
-    writer_db.Close();
-}
-
-TEST_F(JemallocRebuildMetadataTest, ReaderEpochTrackingCanBeEnabledForCoveredLookupPaths)
-{
-    ASSERT_TRUE(CreateJemallocRebuildTestDir());
-    const std::string key("reader-epoch-active");
-    const std::string value("value");
-
-    MBConfig writer_cfg = MakeJemallocRebuildConfig(CONSTS::WriterOptions(), false);
-    DB writer_db(writer_cfg);
-    ASSERT_TRUE(writer_db.is_open());
-    ASSERT_EQ(writer_db.Add(key, value), MBError::SUCCESS);
-
-    MBConfig reader_cfg = MakeJemallocRebuildConfig(CONSTS::ACCESS_MODE_READER, false);
-    reader_cfg.connect_id = 0x5678;
-    DB reader_db(reader_cfg);
-    ASSERT_TRUE(reader_db.is_open());
-
-    IndexHeader* header = writer_db.GetDictPtr()->GetHeaderPtr();
-    ASSERT_NE(header, nullptr);
-
-    header->reader_epoch.store(17, MEMORY_ORDER_WRITER);
-    header->reader_epoch_tracking_active.store(1, MEMORY_ORDER_WRITER);
-    const uint64_t fast_slot_before = reader_db.GetReaderGuardFastSlotCount();
-    const uint64_t barrier_before = reader_db.GetReaderGuardBarrierFallbackCount();
-
-    ExpectFindValue(reader_db, key, value);
-
-    EXPECT_EQ(reader_db.GetReaderGuardFastSlotCount(), fast_slot_before + 1);
-    EXPECT_EQ(reader_db.GetReaderGuardBarrierFallbackCount(), barrier_before);
-    EXPECT_EQ(FindReaderEpochSlot(header, reader_cfg.connect_id), -1);
-    EXPECT_EQ(header->reader_epoch.load(MEMORY_ORDER_READER), 17u);
-    reader_db.Close();
-    writer_db.Close();
-}
-
-TEST_F(JemallocRebuildMetadataTest, RebuildBarrierGuardResourceIsSharedAcrossHandlesForSameDb)
-{
-    ASSERT_TRUE(CreateJemallocRebuildTestDir());
-
-    MBConfig writer_cfg = MakeJemallocRebuildConfig(CONSTS::WriterOptions(), false);
-    DB writer_db(writer_cfg);
-    ASSERT_TRUE(writer_db.is_open());
-
-    MBConfig reader_cfg_1 = MakeJemallocRebuildConfig(CONSTS::ACCESS_MODE_READER, false);
-    reader_cfg_1.connect_id = 0x6011;
-    DB reader_db_1(reader_cfg_1);
-    ASSERT_TRUE(reader_db_1.is_open());
-
-    MBConfig reader_cfg_2 = MakeJemallocRebuildConfig(CONSTS::ACCESS_MODE_READER, false);
-    reader_cfg_2.connect_id = 0x6012;
-    DB reader_db_2(reader_cfg_2);
-    ASSERT_TRUE(reader_db_2.is_open());
-
-    ASSERT_EQ(DBTestPeer::EnsureRebuildGuardFd(reader_db_1), MBError::SUCCESS);
-    ASSERT_EQ(DBTestPeer::EnsureRebuildGuardFd(reader_db_2), MBError::SUCCESS);
-
-    MmapFileIO* guard_1 = DBTestPeer::GetRebuildGuardFile(reader_db_1);
-    MmapFileIO* guard_2 = DBTestPeer::GetRebuildGuardFile(reader_db_2);
-    ASSERT_NE(guard_1, nullptr);
-    ASSERT_NE(guard_2, nullptr);
-    EXPECT_EQ(guard_1, guard_2);
-
-
-    reader_db_2.Close();
-    reader_db_1.Close();
-    writer_db.Close();
-}
-
-TEST_F(JemallocRebuildMetadataTest, ReaderEpochTrackingAlsoCoversFindLongestPrefix)
-{
-    ASSERT_TRUE(CreateJemallocRebuildTestDir());
-    const std::string key("reader-epoch-prefix");
-    const std::string value("value-prefix");
-
-    MBConfig writer_cfg = MakeJemallocRebuildConfig(CONSTS::WriterOptions(), false);
-    DB writer_db(writer_cfg);
-    ASSERT_TRUE(writer_db.is_open());
-    ASSERT_EQ(writer_db.Add(key, value), MBError::SUCCESS);
-
-    MBConfig reader_cfg = MakeJemallocRebuildConfig(CONSTS::ACCESS_MODE_READER, false);
-    reader_cfg.connect_id = 0x6789;
-    DB reader_db(reader_cfg);
-    ASSERT_TRUE(reader_db.is_open());
-
-    IndexHeader* header = writer_db.GetDictPtr()->GetHeaderPtr();
-    ASSERT_NE(header, nullptr);
-
-    header->reader_epoch.store(23, MEMORY_ORDER_WRITER);
-    header->reader_epoch_tracking_active.store(1, MEMORY_ORDER_WRITER);
-    const uint64_t fast_slot_before = reader_db.GetReaderGuardFastSlotCount();
-    const uint64_t barrier_before = reader_db.GetReaderGuardBarrierFallbackCount();
-
-    MBData data;
-    ASSERT_EQ(reader_db.FindLongestPrefix(key, data), MBError::SUCCESS);
-    ASSERT_EQ(std::string(reinterpret_cast<const char*>(data.buff), data.data_len), value);
-
-    EXPECT_EQ(reader_db.GetReaderGuardFastSlotCount(), fast_slot_before + 1);
-    EXPECT_EQ(reader_db.GetReaderGuardBarrierFallbackCount(), barrier_before);
-    EXPECT_EQ(FindReaderEpochSlot(header, reader_cfg.connect_id), -1);
-    EXPECT_EQ(header->reader_epoch.load(MEMORY_ORDER_READER), 23u);
-    reader_db.Close();
-    writer_db.Close();
+    std::ifstream hdr_file(JemallocRebuildTestPath() + "/_mabain_h", std::ios::binary);
+    ASSERT_TRUE(hdr_file.is_open());
+    char hdr_page[RollableFile::page_size];
+    hdr_file.read(hdr_page, sizeof(hdr_page));
+    ASSERT_EQ(hdr_file.gcount(), static_cast<std::streamsize>(sizeof(hdr_page)));
+    EXPECT_TRUE(PersistedRebuildInProgress(hdr_page));
 }
 
 TEST_F(JemallocRebuildMetadataTest, QuarantinedBlockStaysUnavailableWhileReaderPinnedToRetireEpoch)
 {
-    ASSERT_TRUE(CreateJemallocRebuildTestDir());
-
-    MBConfig writer_cfg = MakeJemallocRebuildConfig(
-        CONSTS::ACCESS_MODE_WRITER | CONSTS::OPTION_JEMALLOC, false);
-    DB writer_db(writer_cfg);
+    MBConfig config = MakeJemallocRebuildConfig(CONSTS::ACCESS_MODE_WRITER | CONSTS::OPTION_JEMALLOC, false);
+    DB writer_db(config);
     ASSERT_TRUE(writer_db.is_open());
-
-    IndexHeader* header = writer_db.GetDictPtr()->GetHeaderPtr();
+    auto* header = writer_db.GetDictPtr()->GetHeaderPtr();
     ASSERT_NE(header, nullptr);
-    header->reader_epoch_tracking_active.store(1, MEMORY_ORDER_WRITER);
-    header->reader_epoch_slot[0].connect_id.store(0x1111, MEMORY_ORDER_WRITER);
-    header->reader_epoch_slot[0].pid.store(1, MEMORY_ORDER_WRITER);
-    header->reader_epoch_slot[0].epoch.store(9, MEMORY_ORDER_WRITER);
 
     ResourceCollectionTestPeer rc(writer_db);
-    ASSERT_EQ(rc.QueueReusableBlock(header->reusable_index_block,
-        header->reusable_index_block_count, 2, 9), MBError::SUCCESS);
-    EXPECT_EQ(header->reusable_index_block_count, 1u);
+    ReusableBlockEntry entries[MB_MAX_REUSABLE_BLOCKS] = {};
+    uint32_t count = 0;
+    ASSERT_EQ(rc.QueueReusableBlock(entries, count, 2, 9), MBError::SUCCESS);
+    header->reader_epoch_slot[0].connect_id.store(99, MEMORY_ORDER_WRITER);
+    header->reader_epoch_slot[0].epoch.store(9, MEMORY_ORDER_WRITER);
 
-    ASSERT_EQ(rc.ReleaseReusableBlocks(header->reusable_index_block,
-        header->reusable_index_block_count), MBError::SUCCESS);
-    EXPECT_EQ(header->reusable_index_block_count, 1u);
-    EXPECT_EQ(header->reusable_index_block[0].in_use, REUSABLE_BLOCK_STATE_QUARANTINED);
-    EXPECT_EQ(writer_db.GetDictPtr()->GetMM()->GetReusableBlockCount(), 0u);
-    EXPECT_EQ(header->reader_epoch_tracking_active.load(MEMORY_ORDER_READER), 1u);
-    writer_db.Close();
+    ASSERT_EQ(rc.ReleaseReusableBlocks(entries, count), MBError::SUCCESS);
+    EXPECT_EQ(count, 1u);
+    EXPECT_EQ(entries[0].in_use, REUSABLE_BLOCK_STATE_QUARANTINED);
 }
 
 TEST_F(JemallocRebuildMetadataTest, QuarantinedBlockBecomesReusableAfterReadersAdvance)
 {
-    ASSERT_TRUE(CreateJemallocRebuildTestDir());
-
-    MBConfig writer_cfg = MakeJemallocRebuildConfig(
-        CONSTS::ACCESS_MODE_WRITER | CONSTS::OPTION_JEMALLOC, false);
-    DB writer_db(writer_cfg);
+    MBConfig config = MakeJemallocRebuildConfig(CONSTS::ACCESS_MODE_WRITER | CONSTS::OPTION_JEMALLOC, false);
+    DB writer_db(config);
     ASSERT_TRUE(writer_db.is_open());
-
-    IndexHeader* header = writer_db.GetDictPtr()->GetHeaderPtr();
+    auto* header = writer_db.GetDictPtr()->GetHeaderPtr();
     ASSERT_NE(header, nullptr);
-    header->reader_epoch_tracking_active.store(1, MEMORY_ORDER_WRITER);
-    header->reader_epoch_slot[0].connect_id.store(0x2222, MEMORY_ORDER_WRITER);
-    header->reader_epoch_slot[0].pid.store(1, MEMORY_ORDER_WRITER);
-    header->reader_epoch_slot[0].epoch.store(11, MEMORY_ORDER_WRITER);
 
     ResourceCollectionTestPeer rc(writer_db);
-    ASSERT_EQ(rc.QueueReusableBlock(header->reusable_index_block,
-        header->reusable_index_block_count, 2, 9), MBError::SUCCESS);
-    ASSERT_EQ(rc.QueueReusableBlock(header->reusable_data_block,
-        header->reusable_data_block_count, 3, 9), MBError::SUCCESS);
-
-    header->reader_epoch_slot[0].epoch.store(12, MEMORY_ORDER_WRITER);
-    ASSERT_EQ(rc.ReleaseReusableBlocks(header->reusable_index_block,
-        header->reusable_index_block_count), MBError::SUCCESS);
-    ASSERT_EQ(rc.ReleaseReusableBlocks(header->reusable_data_block,
-        header->reusable_data_block_count), MBError::SUCCESS);
-    EXPECT_EQ(header->reusable_index_block_count, 1u);
-    EXPECT_EQ(header->reusable_data_block_count, 1u);
-    EXPECT_EQ(header->reusable_index_block[0].in_use, REUSABLE_BLOCK_STATE_READY);
-    EXPECT_EQ(header->reusable_data_block[0].in_use, REUSABLE_BLOCK_STATE_READY);
-    EXPECT_EQ(writer_db.GetDictPtr()->GetMM()->GetReusableBlockCount(), 0u);
-    EXPECT_EQ(writer_db.GetDictPtr()->GetReusableBlockCount(), 0u);
-    EXPECT_EQ(header->reader_epoch_tracking_active.load(MEMORY_ORDER_READER), 1u);
-
-    ASSERT_EQ(rc.DrainReusableBlocks(header->reusable_index_block,
-        header->reusable_index_block_count, writer_db.GetDictPtr()->GetMM()), MBError::SUCCESS);
-    ASSERT_EQ(rc.DrainReusableBlocks(header->reusable_data_block,
-        header->reusable_data_block_count, writer_db.GetDictPtr()), MBError::SUCCESS);
-    EXPECT_EQ(header->reusable_index_block_count, 0u);
-    EXPECT_EQ(header->reusable_data_block_count, 0u);
-    EXPECT_EQ(writer_db.GetDictPtr()->GetMM()->GetReusableBlockCount(), 1u);
-    EXPECT_EQ(writer_db.GetDictPtr()->GetReusableBlockCount(), 1u);
-    writer_db.Close();
+    ReusableBlockEntry entries[MB_MAX_REUSABLE_BLOCKS] = {};
+    uint32_t count = 0;
+    ASSERT_EQ(rc.QueueReusableBlock(entries, count, 2, 9), MBError::SUCCESS);
+    header->reader_epoch_slot[0].connect_id.store(99, MEMORY_ORDER_WRITER);
+    header->reader_epoch_slot[0].epoch.store(10, MEMORY_ORDER_WRITER);
+    ASSERT_EQ(rc.ReleaseReusableBlocks(entries, count), MBError::SUCCESS);
+    EXPECT_EQ(entries[0].in_use, REUSABLE_BLOCK_STATE_READY);
 }
 
-TEST_F(JemallocRebuildMetadataTest, DeadReaderEpochSlotIsClearedDuringQuiesceCheck)
+TEST_F(JemallocRebuildMetadataTest, ReaderEpochGuardUsesFastSlotWhenAvailable)
 {
-    ASSERT_TRUE(CreateJemallocRebuildTestDir());
-
-    MBConfig writer_cfg = MakeJemallocRebuildConfig(
-        CONSTS::ACCESS_MODE_WRITER | CONSTS::OPTION_JEMALLOC, false);
-    DB writer_db(writer_cfg);
+    MBConfig writer_config = MakeJemallocRebuildConfig(CONSTS::ACCESS_MODE_WRITER | CONSTS::OPTION_JEMALLOC, false);
+    DB writer_db(writer_config);
     ASSERT_TRUE(writer_db.is_open());
-
-    IndexHeader* header = writer_db.GetDictPtr()->GetHeaderPtr();
+    ASSERT_EQ(writer_db.Add("seed", "value"), MBError::SUCCESS);
+    auto* header = writer_db.GetDictPtr()->GetHeaderPtr();
     ASSERT_NE(header, nullptr);
-    header->reader_epoch_tracking_active.store(1, MEMORY_ORDER_WRITER);
-    header->reader_epoch_slot[0].connect_id.store(0x3333, MEMORY_ORDER_WRITER);
-    header->reader_epoch_slot[0].pid.store(2000000000u, MEMORY_ORDER_WRITER);
-    header->reader_epoch_slot[0].epoch.store(9, MEMORY_ORDER_WRITER);
 
-    ResourceCollectionTestPeer rc(writer_db);
-    ASSERT_EQ(rc.QueueReusableBlock(header->reusable_index_block,
-        header->reusable_index_block_count, 2, 9), MBError::SUCCESS);
-    ASSERT_EQ(rc.ReleaseReusableBlocks(header->reusable_index_block,
-        header->reusable_index_block_count), MBError::SUCCESS);
-    EXPECT_EQ(header->reusable_index_block_count, 1u);
-    EXPECT_EQ(header->reusable_index_block[0].in_use, REUSABLE_BLOCK_STATE_READY);
-    EXPECT_EQ(header->reader_epoch_slot[0].connect_id.load(MEMORY_ORDER_READER), 0u);
-    EXPECT_EQ(header->reader_epoch_slot[0].pid.load(MEMORY_ORDER_READER), 0u);
-    EXPECT_EQ(header->reader_epoch_slot[0].epoch.load(MEMORY_ORDER_READER), 0u);
-    writer_db.Close();
-}
-
-TEST_F(JemallocRebuildMetadataTest, RejectsOlderHeaderVersion)
-{
-    CreateHeaderWithVersion(1, 6, 2);
-    int options = CONSTS::ReaderOptions();
-    DB db(JemallocRebuildTestPath().c_str(), options);
-    EXPECT_FALSE(db.is_open());
-    EXPECT_EQ(db.Status(), MBError::VERSION_MISMATCH);
-}
-
-TEST_F(JemallocRebuildMetadataTest, PersistedHeaderKeepsRebuildMetadata)
-{
-    ASSERT_TRUE(CreateJemallocRebuildTestDir());
-    {
-        DB writer_db(JemallocRebuildTestPath().c_str(), CONSTS::WriterOptions());
-        ASSERT_TRUE(writer_db.is_open());
-        IndexHeader* header = writer_db.GetDictPtr()->GetHeaderPtr();
-        ASSERT_NE(header, nullptr);
-
-        header->rebuild_state = REBUILD_STATE_COPY;
-        header->rebuild_root_offset = 4321;
-        header->rebuild_index_alloc_start = 1001;
-        header->rebuild_data_alloc_start = 1002;
-        header->rebuild_cutover_index = 12;
-        header->rebuild_index_alloc_end = 2001;
-        header->rebuild_data_alloc_end = 2002;
-        header->rebuild_index_source_end = 3001;
-        header->rebuild_data_source_end = 3002;
-        header->rebuild_index_block_cursor = 4001;
-        header->rebuild_data_block_cursor = 4002;
-        header->reusable_index_block_count = 6;
-        header->reusable_data_block_count = 7;
-        writer_db.Close();
-    }
-
-    char hdr_page[RollableFile::page_size];
-    std::ifstream in(JemallocRebuildTestPath() + "/_mabain_h",
-        std::ios::in | std::ios::binary);
-    ASSERT_TRUE(in.is_open());
-    in.read(hdr_page, sizeof(hdr_page));
-    ASSERT_EQ(in.gcount(), static_cast<std::streamsize>(sizeof(hdr_page)));
-
-        EXPECT_EQ(ReadPersistedHeaderField<int>(hdr_page, offsetof(IndexHeader, rebuild_state)), REBUILD_STATE_COPY);
-    EXPECT_EQ(ReadPersistedHeaderField<size_t>(hdr_page, offsetof(IndexHeader, rebuild_root_offset)), 4321u);
-    EXPECT_EQ(ReadPersistedHeaderField<size_t>(hdr_page, offsetof(IndexHeader, rebuild_index_alloc_start)), 1001u);
-    EXPECT_EQ(ReadPersistedHeaderField<size_t>(hdr_page, offsetof(IndexHeader, rebuild_data_alloc_start)), 1002u);
-    EXPECT_EQ(ReadPersistedHeaderField<int>(hdr_page, offsetof(IndexHeader, rebuild_cutover_index)), 12);
-    EXPECT_EQ(ReadPersistedHeaderField<size_t>(hdr_page, offsetof(IndexHeader, rebuild_index_alloc_end)), 2001u);
-    EXPECT_EQ(ReadPersistedHeaderField<size_t>(hdr_page, offsetof(IndexHeader, rebuild_data_alloc_end)), 2002u);
-    EXPECT_EQ(ReadPersistedHeaderField<size_t>(hdr_page, offsetof(IndexHeader, rebuild_index_source_end)), 3001u);
-    EXPECT_EQ(ReadPersistedHeaderField<size_t>(hdr_page, offsetof(IndexHeader, rebuild_data_source_end)), 3002u);
-    EXPECT_EQ(ReadPersistedHeaderField<size_t>(hdr_page, offsetof(IndexHeader, rebuild_index_block_cursor)), 4001u);
-    EXPECT_EQ(ReadPersistedHeaderField<size_t>(hdr_page, offsetof(IndexHeader, rebuild_data_block_cursor)), 4002u);
-    EXPECT_EQ(ReadPersistedHeaderField<uint32_t>(hdr_page, offsetof(IndexHeader, reusable_index_block_count)), 6u);
-    EXPECT_EQ(ReadPersistedHeaderField<uint32_t>(hdr_page, offsetof(IndexHeader, reusable_data_block_count)), 7u);
-    EXPECT_TRUE(PersistedRebuildInProgress(hdr_page));
-}
-
-TEST_F(JemallocRebuildMetadataTest, WriterRecreatesDbAfterOlderHeaderVersionMismatch)
-{
-    CreateHeaderWithVersion(1, 6, 2);
-    DB writer_db(JemallocRebuildTestPath().c_str(), CONSTS::WriterOptions());
-    ASSERT_TRUE(writer_db.is_open());
-    EXPECT_EQ(writer_db.Status(), MBError::SUCCESS);
-
-    IndexHeader* header = writer_db.GetDictPtr()->GetHeaderPtr();
-    ASSERT_NE(header, nullptr);
-    EXPECT_EQ(header->version[0], version[0]);
-    EXPECT_EQ(header->version[1], version[1]);
-    EXPECT_EQ(header->version[2], version[2]);
-    EXPECT_EQ(header->rebuild_state, REBUILD_STATE_NORMAL);
-    EXPECT_EQ(header->rebuild_root_offset, 0u);
-    EXPECT_EQ(header->rebuild_index_alloc_start, 0u);
-    EXPECT_EQ(header->rebuild_data_alloc_start, 0u);
-    EXPECT_EQ(header->rebuild_cutover_index, 0);
-    EXPECT_EQ(header->rebuild_index_alloc_end, 0u);
-    EXPECT_EQ(header->rebuild_data_alloc_end, 0u);
-    EXPECT_FALSE(header->RebuildInProgress());
-    writer_db.Close();
-}
-
-TEST_F(JemallocRebuildMetadataTest, WarmRestartWithKeepDbCompletesStartupRebuildAndPreservesReads)
-{
-    ASSERT_TRUE(CreateJemallocRebuildTestDir());
-    const std::string key("alpha");
-    const std::string key2("alpha-2");
-    const std::string value("value-alpha");
-
-    MBConfig initial_cfg = MakeJemallocRebuildConfig(
-        CONSTS::ACCESS_MODE_WRITER | CONSTS::OPTION_JEMALLOC, false);
-    DB initial_db(initial_cfg);
-    ASSERT_TRUE(initial_db.is_open());
-    ASSERT_EQ(initial_db.Add(key, value), MBError::SUCCESS);
-    ASSERT_EQ(initial_db.Count(), 1);
-    IndexHeader* initial_header = initial_db.GetDictPtr()->GetHeaderPtr();
-    ASSERT_NE(initial_header, nullptr);
-    initial_header->pending_index_buff_size = 12345;
-    initial_header->pending_data_buff_size = 23456;
-    initial_db.Close();
-
-    MBConfig rebuild_cfg = MakeJemallocRebuildConfig(
-        CONSTS::ACCESS_MODE_WRITER | CONSTS::OPTION_JEMALLOC, true);
-    DB rebuild_db(rebuild_cfg);
-    ASSERT_TRUE(rebuild_db.is_open());
-
-    IndexHeader* header = rebuild_db.GetDictPtr()->GetHeaderPtr();
-    ASSERT_NE(header, nullptr);
-    EXPECT_EQ(header->rebuild_state, REBUILD_STATE_NORMAL);
-    EXPECT_FALSE(header->RebuildInProgress());
-    EXPECT_EQ(header->reader_epoch_tracking_active.load(MEMORY_ORDER_READER), 0u);
-    EXPECT_EQ(header->pending_index_buff_size, 0);
-    EXPECT_EQ(header->pending_data_buff_size, 0);
-    EXPECT_EQ(rebuild_db.Count(), 1);
-    ExpectFindValue(rebuild_db, key, value);
-    ASSERT_EQ(rebuild_db.Add(key2, value), MBError::SUCCESS);
-    EXPECT_EQ(rebuild_db.Count(), 2);
-    ExpectFindValue(rebuild_db, key2, value);
-    EXPECT_EQ(header->reusable_index_block_count, 0u);
-    EXPECT_EQ(header->reusable_data_block_count, 0u);
-
-    MBConfig reader_cfg = MakeJemallocRebuildConfig(CONSTS::ACCESS_MODE_READER, false);
-    DB reader_db(reader_cfg);
+    MBConfig config = MakeJemallocRebuildConfig(CONSTS::ACCESS_MODE_READER | CONSTS::OPTION_JEMALLOC, false);
+    config.connect_id = 77;
+    DB reader_db(config);
     ASSERT_TRUE(reader_db.is_open());
-    ExpectFindValue(reader_db, key, value);
-    ExpectFindValue(reader_db, key2, value);
-    reader_db.Close();
-    rebuild_db.Close();
-    ResourcePool::getInstance().RemoveAll();
+    header->reader_epoch_tracking_active.store(1, MEMORY_ORDER_WRITER);
+
+    const uint64_t fast_before = reader_db.GetReaderGuardFastSlotCount();
+    const uint64_t fallback_before = reader_db.GetReaderGuardBarrierFallbackCount();
+    const uint64_t token = mabain::DBTestPeer::BeginReaderEpochGuard(reader_db);
+    EXPECT_NE(token, 0u);
+    EXPECT_EQ(reader_db.GetReaderGuardFastSlotCount(), fast_before + 1);
+    EXPECT_EQ(reader_db.GetReaderGuardBarrierFallbackCount(), fallback_before);
+    EXPECT_EQ(header->reader_epoch_slot[token - 1].connect_id.load(MEMORY_ORDER_READER), 77u);
+    mabain::DBTestPeer::EndReaderEpochGuard(reader_db, token);
+}
+
+TEST_F(JemallocRebuildMetadataTest, ReaderEpochGuardFallsBackToBarrierWhenSlotsBusy)
+{
+    MBConfig writer_config = MakeJemallocRebuildConfig(CONSTS::ACCESS_MODE_WRITER | CONSTS::OPTION_JEMALLOC, false);
+    DB writer_db(writer_config);
+    ASSERT_TRUE(writer_db.is_open());
+    ASSERT_EQ(writer_db.Add("seed", "value"), MBError::SUCCESS);
+    auto* header = writer_db.GetDictPtr()->GetHeaderPtr();
+    ASSERT_NE(header, nullptr);
+
+    MBConfig config = MakeJemallocRebuildConfig(CONSTS::ACCESS_MODE_READER | CONSTS::OPTION_JEMALLOC, false);
+    config.connect_id = 88;
+    DB reader_db(config);
+    ASSERT_TRUE(reader_db.is_open());
+    header->reader_epoch_tracking_active.store(1, MEMORY_ORDER_WRITER);
+    for (uint32_t i = 0; i < MB_MAX_READER_EPOCH_SLOT; ++i)
+        header->reader_epoch_slot[i].connect_id.store(i + 1, MEMORY_ORDER_WRITER);
+
+    const uint64_t fast_before = reader_db.GetReaderGuardFastSlotCount();
+    const uint64_t fallback_before = reader_db.GetReaderGuardBarrierFallbackCount();
+    const uint64_t token = mabain::DBTestPeer::BeginReaderEpochGuard(reader_db);
+    EXPECT_NE(token, 0u);
+    EXPECT_EQ(reader_db.GetReaderGuardFastSlotCount(), fast_before);
+    EXPECT_EQ(reader_db.GetReaderGuardBarrierFallbackCount(), fallback_before + 1);
+    mabain::DBTestPeer::EndReaderEpochGuard(reader_db, token);
+}
+
+TEST_F(JemallocRebuildMetadataTest, ReaderEpochGuardEndClearsClaimedSlot)
+{
+    MBConfig writer_config = MakeJemallocRebuildConfig(CONSTS::ACCESS_MODE_WRITER | CONSTS::OPTION_JEMALLOC, false);
+    DB writer_db(writer_config);
+    ASSERT_TRUE(writer_db.is_open());
+    ASSERT_EQ(writer_db.Add("seed", "value"), MBError::SUCCESS);
+    auto* header = writer_db.GetDictPtr()->GetHeaderPtr();
+    ASSERT_NE(header, nullptr);
+
+    MBConfig config = MakeJemallocRebuildConfig(CONSTS::ACCESS_MODE_READER | CONSTS::OPTION_JEMALLOC, false);
+    config.connect_id = 123;
+    DB reader_db(config);
+    ASSERT_TRUE(reader_db.is_open());
+    header->reader_epoch_tracking_active.store(1, MEMORY_ORDER_WRITER);
+
+    const uint64_t token = mabain::DBTestPeer::BeginReaderEpochGuard(reader_db);
+    ASSERT_NE(token, 0u);
+    mabain::DBTestPeer::EndReaderEpochGuard(reader_db, token);
+    EXPECT_EQ(header->reader_epoch_slot[token - 1].connect_id.load(MEMORY_ORDER_READER), 0u);
 }
 
 TEST_F(JemallocRebuildMetadataTest, RunStartupRebuildOnReaderReturnsControlledError)
 {
-    ASSERT_TRUE(CreateJemallocRebuildTestDir());
-    const std::string key("reader-rebuild");
-    const std::string value("value-reader");
-
-    MBConfig writer_cfg = MakeJemallocRebuildConfig(
-        CONSTS::ACCESS_MODE_WRITER | CONSTS::OPTION_JEMALLOC, false);
-    DB writer_db(writer_cfg);
+    MBConfig writer_config = MakeJemallocRebuildConfig(CONSTS::ACCESS_MODE_WRITER | CONSTS::OPTION_JEMALLOC, false);
+    DB writer_db(writer_config);
     ASSERT_TRUE(writer_db.is_open());
-    ASSERT_EQ(writer_db.Add(key, value), MBError::SUCCESS);
+    ASSERT_EQ(writer_db.Add("existing", "value"), MBError::SUCCESS);
+    writer_db.Close();
 
-    IndexHeader* header = writer_db.GetDictPtr()->GetHeaderPtr();
-    ASSERT_NE(header, nullptr);
-
-    MBConfig reader_cfg = MakeJemallocRebuildConfig(CONSTS::ACCESS_MODE_READER, false);
-    DB reader_db(reader_cfg);
+    MBConfig reader_config = MakeJemallocRebuildConfig(CONSTS::ACCESS_MODE_READER, true);
+    DB reader_db(reader_config);
     ASSERT_TRUE(reader_db.is_open());
-
-    header->ResetRebuildMetadata(REBUILD_STATE_PREP);
-
     EXPECT_EQ(mabain::DBTestPeer::RunStartupRebuild(reader_db), MBError::NOT_ALLOWED);
-    EXPECT_TRUE(header->RebuildInProgress());
-    ExpectFindValue(reader_db, key, value);
-
-    header->ClearRebuildMetadata();
-    reader_db.Close();
-    writer_db.Close();
 }
 
-TEST_F(JemallocRebuildMetadataTest, RunStartupRebuildRejectsIncompleteCopyMetadata)
+TEST_F(JemallocRebuildMetadataTest, RunStartupRebuildWithExceptionStatusClearsDbWithoutRecovery)
 {
-    ASSERT_TRUE(CreateJemallocRebuildTestDir());
-    const std::string key("incomplete-copy");
-    const std::string value("value-copy");
-
-    MBConfig writer_cfg = MakeJemallocRebuildConfig(
-        CONSTS::ACCESS_MODE_WRITER | CONSTS::OPTION_JEMALLOC, false);
-    DB writer_db(writer_cfg);
-    ASSERT_TRUE(writer_db.is_open());
-    ASSERT_EQ(writer_db.Add(key, value), MBError::SUCCESS);
-
-    IndexHeader* header = writer_db.GetDictPtr()->GetHeaderPtr();
-    ASSERT_NE(header, nullptr);
-    header->ResetRebuildMetadata(REBUILD_STATE_COPY);
-    header->rebuild_index_alloc_end = header->m_index_offset;
-    header->rebuild_data_alloc_end = header->m_data_offset;
-
-    EXPECT_FALSE(mabain::DBTestPeer::StartupRebuildComplete(writer_db));
-    EXPECT_EQ(mabain::DBTestPeer::RunStartupRebuild(writer_db), MBError::INVALID_SIZE);
-    EXPECT_EQ(header->rebuild_state, REBUILD_STATE_COPY);
-    EXPECT_TRUE(header->RebuildInProgress());
-    EXPECT_EQ(header->rebuild_index_source_end, 0u);
-    EXPECT_EQ(header->rebuild_data_source_end, 0u);
-    ExpectFindValue(writer_db, key, value);
-
-    header->ClearRebuildMetadata();
-    writer_db.Close();
-}
-
-TEST_F(JemallocRebuildMetadataTest, StartupShrinkCapturesCurrentJemallocTails)
-{
-    ASSERT_TRUE(CreateJemallocRebuildTestDir());
-    const std::string key("delta");
-    const std::string value("value-delta");
-
-    MBConfig initial_cfg = MakeJemallocRebuildConfig(
-        CONSTS::ACCESS_MODE_WRITER | CONSTS::OPTION_JEMALLOC, false);
-    DB initial_db(initial_cfg);
-    ASSERT_TRUE(initial_db.is_open());
-    ASSERT_EQ(initial_db.Add(key, value), MBError::SUCCESS);
-
-    IndexHeader* header = initial_db.GetDictPtr()->GetHeaderPtr();
-    ASSERT_NE(header, nullptr);
-    header->ResetRebuildMetadata(REBUILD_STATE_PREP);
-    ASSERT_EQ(header->rebuild_state, REBUILD_STATE_PREP);
-    ResourceCollection rc(initial_db);
-    ASSERT_EQ(rc.StartupShrink(), MBError::SUCCESS);
-    EXPECT_EQ(header->rebuild_state, REBUILD_STATE_COPY);
-    EXPECT_EQ(header->rebuild_index_alloc_start, header->m_index_offset);
-    EXPECT_EQ(header->rebuild_data_alloc_start, header->m_data_offset);
-    EXPECT_LE(header->rebuild_index_alloc_end, header->rebuild_index_alloc_start);
-    EXPECT_LE(header->rebuild_data_alloc_end, header->rebuild_data_alloc_start);
-    EXPECT_GE(header->rebuild_index_source_end, header->m_index_offset);
-    EXPECT_GE(header->rebuild_data_source_end, header->m_data_offset);
-    EXPECT_GE(header->rebuild_index_source_end, header->rebuild_index_alloc_end);
-    EXPECT_GE(header->rebuild_data_source_end, header->rebuild_data_alloc_end);
-    initial_db.Close();
-}
-
-TEST_F(JemallocRebuildMetadataTest, StartupEvacuateSeparatesExactBoundaryFromSourceBlockStart)
-{
-    ASSERT_TRUE(CreateJemallocRebuildTestDir());
-    const std::string key("epsilon");
-    const std::string value("value-epsilon");
-
-    MBConfig initial_cfg = MakeJemallocRebuildConfig(
-        CONSTS::ACCESS_MODE_WRITER | CONSTS::OPTION_JEMALLOC, false);
-    DB initial_db(initial_cfg);
-    ASSERT_TRUE(initial_db.is_open());
-    ASSERT_EQ(initial_db.Add(key, value), MBError::SUCCESS);
-
-    IndexHeader* header = initial_db.GetDictPtr()->GetHeaderPtr();
-    ASSERT_NE(header, nullptr);
-    header->ResetRebuildMetadata(REBUILD_STATE_PREP);
-    ResourceCollection rc(initial_db);
-    ASSERT_EQ(rc.StartupShrink(), MBError::SUCCESS);
-
-    ASSERT_NE(header, nullptr);
-    const size_t index_boundary = header->rebuild_index_alloc_end;
-    const size_t data_boundary = header->rebuild_data_alloc_end;
-    ASSERT_GT(header->index_block_size, 0u);
-    ASSERT_GT(header->data_block_size, 0u);
-
-    ASSERT_EQ(rc.StartupEvacuate(), MBError::SUCCESS);
-    EXPECT_EQ(header->rebuild_state, REBUILD_STATE_CUTOVER);
-    EXPECT_EQ(header->rebuild_index_alloc_end, index_boundary);
-    EXPECT_EQ(header->rebuild_data_alloc_end, data_boundary);
-    EXPECT_GE(initial_db.GetDictPtr()->GetMM()->GetJemallocAllocSize(), index_boundary);
-    EXPECT_GE(initial_db.GetDictPtr()->GetJemallocAllocSize(), data_boundary);
-    EXPECT_EQ(header->rebuild_index_alloc_start % header->index_block_size, 0u);
-    EXPECT_EQ(header->rebuild_data_alloc_start % header->data_block_size, 0u);
-    EXPECT_GE(header->rebuild_index_alloc_start, header->rebuild_index_alloc_end);
-    EXPECT_GE(header->rebuild_data_alloc_start, header->rebuild_data_alloc_end);
-    EXPECT_GE(header->rebuild_index_block_cursor, header->rebuild_index_alloc_start);
-    EXPECT_LE(header->rebuild_index_block_cursor, header->rebuild_index_source_end);
-    EXPECT_GE(header->rebuild_data_block_cursor, header->rebuild_data_alloc_start);
-    EXPECT_LE(header->rebuild_data_block_cursor, header->rebuild_data_source_end);
-    EXPECT_LE(header->reusable_index_block_count, 1u);
-    EXPECT_LE(header->reusable_data_block_count, 1u);
-    if (header->reusable_index_block_count == 1u) {
-        EXPECT_EQ(header->reusable_index_block[0].in_use, REUSABLE_BLOCK_STATE_READY);
-    }
-    if (header->reusable_data_block_count == 1u) {
-        EXPECT_EQ(header->reusable_data_block[0].in_use, REUSABLE_BLOCK_STATE_READY);
-    }
-    EXPECT_EQ(header->reader_epoch_tracking_active.load(MEMORY_ORDER_READER),
-        (header->rebuild_index_block_cursor < header->rebuild_index_source_end
-            || header->rebuild_data_block_cursor < header->rebuild_data_source_end) ? 1u : 0u);
-
-    if (index_boundary % header->index_block_size == 0)
-        EXPECT_EQ(header->rebuild_index_alloc_start, index_boundary);
-    else
-        EXPECT_GT(header->rebuild_index_alloc_start, index_boundary);
-
-    if (data_boundary % header->data_block_size == 0)
-        EXPECT_EQ(header->rebuild_data_alloc_start, data_boundary);
-    else
-        EXPECT_GT(header->rebuild_data_alloc_start, data_boundary);
-    initial_db.Close();
-}
-
-TEST_F(JemallocRebuildMetadataTest, StartupEvacuateResumesFromCutoverState)
-{
-    ASSERT_TRUE(CreateJemallocRebuildTestDir());
-    const std::string key("zeta");
-    const std::string value("value-zeta");
-
-    MBConfig initial_cfg = MakeJemallocRebuildConfig(
-        CONSTS::ACCESS_MODE_WRITER | CONSTS::OPTION_JEMALLOC, false);
-    DB initial_db(initial_cfg);
-    ASSERT_TRUE(initial_db.is_open());
-    ASSERT_EQ(initial_db.Add(key, value), MBError::SUCCESS);
-
-    IndexHeader* header = initial_db.GetDictPtr()->GetHeaderPtr();
-    ASSERT_NE(header, nullptr);
-    header->ResetRebuildMetadata(REBUILD_STATE_PREP);
-    ResourceCollection rc(initial_db);
-    ASSERT_EQ(rc.StartupShrink(), MBError::SUCCESS);
-    ASSERT_EQ(rc.StartupEvacuate(), MBError::SUCCESS);
-
-    ASSERT_NE(header, nullptr);
-    const size_t index_source_start = header->rebuild_index_alloc_start;
-    const size_t data_source_start = header->rebuild_data_alloc_start;
-    const size_t index_boundary = header->rebuild_index_alloc_end;
-    const size_t data_boundary = header->rebuild_data_alloc_end;
-    const size_t index_source_end = header->rebuild_index_source_end;
-    const size_t data_source_end = header->rebuild_data_source_end;
-    const size_t index_cursor_1 = header->rebuild_index_block_cursor;
-    const size_t data_cursor_1 = header->rebuild_data_block_cursor;
-
-    ASSERT_EQ(rc.StartupEvacuate(), MBError::SUCCESS);
-    EXPECT_EQ(header->rebuild_state, REBUILD_STATE_CUTOVER);
-    EXPECT_EQ(header->rebuild_index_alloc_start, index_source_start);
-    EXPECT_EQ(header->rebuild_data_alloc_start, data_source_start);
-    EXPECT_EQ(header->rebuild_index_alloc_end, index_boundary);
-    EXPECT_EQ(header->rebuild_data_alloc_end, data_boundary);
-    EXPECT_EQ(header->rebuild_index_source_end, index_source_end);
-    EXPECT_EQ(header->rebuild_data_source_end, data_source_end);
-    EXPECT_GE(header->rebuild_index_block_cursor, index_cursor_1);
-    EXPECT_GE(header->rebuild_data_block_cursor, data_cursor_1);
-    EXPECT_LE(header->rebuild_data_block_cursor, header->rebuild_data_source_end);
-    EXPECT_LE(header->rebuild_index_block_cursor, header->rebuild_index_source_end);
-    EXPECT_GE(initial_db.GetDictPtr()->GetMM()->GetJemallocAllocSize(), index_boundary);
-    EXPECT_GE(initial_db.GetDictPtr()->GetJemallocAllocSize(), data_boundary);
-    ExpectFindValue(initial_db, key, value);
-    initial_db.Close();
-}
-
-TEST_F(JemallocRebuildMetadataTest, StartupEvacuateDrainsOneFullIndexSourceBlockOnNextPassWhenReadersAreIdle)
-{
-    ASSERT_TRUE(CreateJemallocRebuildTestDir());
-    const uint32_t small_block_size = 4 * 1024 * 1024;
-    const int small_max_blocks = 64;
-    const std::string value(256, 'v');
-    std::vector<std::string> keys;
-
-    MBConfig initial_cfg = MakeSizedJemallocRebuildConfig(
-        CONSTS::ACCESS_MODE_WRITER | CONSTS::OPTION_JEMALLOC, false,
-        small_block_size, small_max_blocks);
-    DB initial_db(initial_cfg);
-    ASSERT_TRUE(initial_db.is_open());
-    for (int i = 0;
-         i < 200000 && initial_db.GetDictPtr()->GetMM()->GetExistingBlockEnd() < 2 * small_block_size;
-         i++) {
-        keys.push_back("evac-" + std::to_string(i) + std::string(24, 'k'));
-        ASSERT_EQ(initial_db.Add(keys.back(), value), MBError::SUCCESS);
-    }
-    ASSERT_GE(initial_db.GetDictPtr()->GetMM()->GetExistingBlockEnd(), 2 * small_block_size);
-    ASSERT_GT(keys.size(), 300u);
-
-    for (size_t i = 0; i + 300 < keys.size(); i++)
-        ASSERT_EQ(initial_db.Remove(keys[i]), MBError::SUCCESS);
-
-    IndexHeader* header = initial_db.GetDictPtr()->GetHeaderPtr();
-    ASSERT_NE(header, nullptr);
-    header->ResetRebuildMetadata(REBUILD_STATE_PREP);
-    ResourceCollection rc(initial_db);
-    ASSERT_EQ(rc.StartupShrink(), MBError::SUCCESS);
-
-    ASSERT_NE(header, nullptr);
-    const size_t first_source_block =
-        ((header->rebuild_index_alloc_end + header->index_block_size - 1) / header->index_block_size)
-        * header->index_block_size;
-    ASSERT_GE(header->rebuild_index_source_end,
-        first_source_block + header->index_block_size);
-
-    ASSERT_EQ(rc.StartupEvacuate(), MBError::SUCCESS);
-    EXPECT_EQ(header->rebuild_state, REBUILD_STATE_CUTOVER);
-    EXPECT_EQ(header->rebuild_index_block_cursor, first_source_block + header->index_block_size);
-    EXPECT_EQ(header->reusable_index_block_count, 1u);
-    EXPECT_EQ(header->reusable_index_block[0].in_use, REUSABLE_BLOCK_STATE_QUARANTINED);
-    EXPECT_EQ(initial_db.GetDictPtr()->GetMM()->GetReusableBlockCount(), 0u);
-
-    ASSERT_EQ(rc.StartupEvacuate(), MBError::SUCCESS);
-    EXPECT_GE(initial_db.GetDictPtr()->GetMM()->GetReusableBlockCount(), 1u);
-    ExpectFindValue(initial_db, keys.back(), value);
-    initial_db.Close();
-}
-
-TEST_F(JemallocRebuildMetadataTest, StartupEvacuateRejectsEmptySourceWindowGracefully)
-{
-    ASSERT_TRUE(CreateJemallocRebuildTestDir());
-    MBConfig rebuild_cfg = MakeJemallocRebuildConfig(
-        CONSTS::ACCESS_MODE_WRITER | CONSTS::OPTION_JEMALLOC, true);
-    DB rebuild_db(rebuild_cfg);
-    ASSERT_TRUE(rebuild_db.is_open());
-
-    IndexHeader* header = rebuild_db.GetDictPtr()->GetHeaderPtr();
-    ASSERT_NE(header, nullptr);
-    header->ResetRebuildMetadata(REBUILD_STATE_COPY);
-    header->rebuild_index_alloc_end = header->index_block_size;
-    header->rebuild_data_alloc_end = header->data_block_size;
-    header->rebuild_index_source_end = header->index_block_size;
-    header->rebuild_data_source_end = header->data_block_size;
-
-    ResourceCollection rc(rebuild_db);
-    EXPECT_EQ(rc.StartupEvacuate(), MBError::SUCCESS);
-    EXPECT_EQ(header->reader_epoch_tracking_active.load(MEMORY_ORDER_READER), 0u);
-    EXPECT_EQ(header->rebuild_index_block_cursor, header->rebuild_index_alloc_start);
-
-    header->ResetRebuildMetadata(REBUILD_STATE_COPY);
-    header->rebuild_index_alloc_end = header->index_block_size + 1;
-    header->rebuild_data_alloc_end = header->data_block_size + 1;
-    header->rebuild_index_source_end = header->index_block_size;
-    header->rebuild_data_source_end = header->data_block_size + 1;
-
-    EXPECT_EQ(rc.StartupEvacuate(), MBError::INVALID_SIZE);
-    EXPECT_EQ(header->rebuild_state, REBUILD_STATE_COPY);
-    rebuild_db.Close();
-}
-
-TEST_F(JemallocRebuildMetadataTest, StartupShrinkRejectsNonJemallocWriterGracefully)
-{
-    ASSERT_TRUE(CreateJemallocRebuildTestDir());
-    DB db(JemallocRebuildTestPath().c_str(), CONSTS::WriterOptions());
-    ASSERT_TRUE(db.is_open());
-
-    IndexHeader* header = db.GetDictPtr()->GetHeaderPtr();
-    ASSERT_NE(header, nullptr);
-    header->ResetRebuildMetadata(REBUILD_STATE_PREP);
-
-    ResourceCollection rc(db);
-    EXPECT_EQ(rc.StartupShrink(), MBError::NOT_ALLOWED);
-    EXPECT_EQ(header->rebuild_state, REBUILD_STATE_PREP);
-    EXPECT_EQ(header->rebuild_index_alloc_start, 0u);
-    EXPECT_EQ(header->rebuild_data_alloc_start, 0u);
-    EXPECT_EQ(header->rebuild_index_alloc_end, 0u);
-    EXPECT_EQ(header->rebuild_data_alloc_end, 0u);
-
-    MBData data;
-    EXPECT_EQ(db.Find("missing", data), MBError::NOT_EXIST);
-    db.Close();
-}
-
-TEST_F(JemallocRebuildMetadataTest, WarmRestartWithAsyncWriterIsRejectedAndKeepsExistingData)
-{
-    ASSERT_TRUE(CreateJemallocRebuildTestDir());
-    const std::string key("beta");
-    const std::string value("value-beta");
-
-    MBConfig initial_cfg = MakeJemallocRebuildConfig(
-        CONSTS::ACCESS_MODE_WRITER | CONSTS::OPTION_JEMALLOC, false);
-    DB initial_db(initial_cfg);
-    ASSERT_TRUE(initial_db.is_open());
-    ASSERT_EQ(initial_db.Add(key, value), MBError::SUCCESS);
-    initial_db.Close();
-
+    MBConfig config = MakeJemallocRebuildConfig(CONSTS::ACCESS_MODE_WRITER | CONSTS::OPTION_JEMALLOC, false);
     {
-        MBConfig reject_cfg = MakeJemallocRebuildConfig(
-            CONSTS::ACCESS_MODE_WRITER | CONSTS::OPTION_JEMALLOC | CONSTS::ASYNC_WRITER_MODE, true);
-        DB rejected_db(reject_cfg);
-        EXPECT_FALSE(rejected_db.is_open());
-        EXPECT_EQ(rejected_db.Status(), MBError::NOT_ALLOWED);
+        DB writer_db(config);
+        ASSERT_TRUE(writer_db.is_open());
+        ASSERT_EQ(writer_db.Add("existing", "value"), MBError::SUCCESS);
+        auto* header = writer_db.GetDictPtr()->GetHeaderPtr();
+        ASSERT_NE(header, nullptr);
+        header->excep_updating_status = EXCEP_STATUS_ADD_EDGE;
     }
 
-    ResourcePool::getInstance().RemoveAll();
+    config.jemalloc_keep_db = true;
+    DB reopen_db(config);
+    ASSERT_TRUE(reopen_db.is_open());
+    EXPECT_EQ(reopen_db.Count(), 0);
+    auto* header = reopen_db.GetDictPtr()->GetHeaderPtr();
+    ASSERT_NE(header, nullptr);
+    EXPECT_EQ(header->rebuild_active, 0u);
+    EXPECT_EQ(header->excep_updating_status, EXCEP_STATUS_NONE);
+    ExpectMissing(reopen_db, "existing");
+}
 
-    MBConfig reader_cfg = MakeJemallocRebuildConfig(CONSTS::ACCESS_MODE_READER, false);
-    DB reader_db(reader_cfg);
-    ASSERT_TRUE(reader_db.is_open());
-    ExpectFindValue(reader_db, key, value);
-    reader_db.Close();
+TEST_F(JemallocRebuildMetadataTest, RunStartupRebuildWithStaleMarkerClearsDb)
+{
+    MBConfig config = MakeJemallocRebuildConfig(CONSTS::ACCESS_MODE_WRITER | CONSTS::OPTION_JEMALLOC, false);
+    {
+        DB writer_db(config);
+        ASSERT_TRUE(writer_db.is_open());
+        ASSERT_EQ(writer_db.Add("existing", "value"), MBError::SUCCESS);
+        auto* header = writer_db.GetDictPtr()->GetHeaderPtr();
+        ASSERT_NE(header, nullptr);
+        header->rebuild_active = 1;
+    }
 
-    char hdr_page[RollableFile::page_size];
-    std::ifstream in(JemallocRebuildTestPath() + "/_mabain_h",
-        std::ios::in | std::ios::binary);
-    ASSERT_TRUE(in.is_open());
-    in.read(hdr_page, sizeof(hdr_page));
-    ASSERT_EQ(in.gcount(), static_cast<std::streamsize>(sizeof(hdr_page)));
+    config.jemalloc_keep_db = true;
+    DB reopen_db(config);
+    ASSERT_TRUE(reopen_db.is_open());
+    EXPECT_EQ(reopen_db.Count(), 0);
+    auto* header = reopen_db.GetDictPtr()->GetHeaderPtr();
+    ASSERT_NE(header, nullptr);
+    EXPECT_EQ(header->rebuild_active, 0u);
+    ExpectMissing(reopen_db, "existing");
+}
 
-    EXPECT_EQ(ReadPersistedHeaderField<int>(hdr_page, offsetof(IndexHeader, rebuild_state)), REBUILD_STATE_NORMAL);
-    EXPECT_FALSE(PersistedRebuildInProgress(hdr_page));
+TEST_F(JemallocRebuildMetadataTest, WarmRestartWithKeepDbCompletesStartupRebuildAndPreservesReads)
+{
+    MBConfig config = MakeSizedJemallocRebuildConfig(
+        CONSTS::ACCESS_MODE_WRITER | CONSTS::OPTION_JEMALLOC, false, 512 * 1024, 8);
+    {
+        DB writer_db(config);
+        ASSERT_TRUE(writer_db.is_open());
+        PopulateAndFragment(writer_db, 256, 2048);
+        ASSERT_EQ(writer_db.Add("steady", "value"), MBError::SUCCESS);
+    }
+
+    config.jemalloc_keep_db = true;
+    DB reopen_db(config);
+    ASSERT_TRUE(reopen_db.is_open());
+    auto* header = reopen_db.GetDictPtr()->GetHeaderPtr();
+    ASSERT_NE(header, nullptr);
+    EXPECT_EQ(header->rebuild_active, 0u);
+    EXPECT_GT(header->jemalloc_index_free_start, 0u);
+    EXPECT_GT(header->jemalloc_data_free_start, 0u);
+    ExpectValue(reopen_db, "steady", "value");
 }
 
 TEST_F(JemallocRebuildMetadataTest, WarmRestartWithoutKeepDbResetsExistingJemallocData)
 {
-    ASSERT_TRUE(CreateJemallocRebuildTestDir());
-    const std::string key("gamma");
-    const std::string value("value-gamma");
+    MBConfig config = MakeJemallocRebuildConfig(CONSTS::ACCESS_MODE_WRITER | CONSTS::OPTION_JEMALLOC, false);
+    {
+        DB writer_db(config);
+        ASSERT_TRUE(writer_db.is_open());
+        ASSERT_EQ(writer_db.Add("existing", "value"), MBError::SUCCESS);
+    }
 
-    MBConfig initial_cfg = MakeJemallocRebuildConfig(
-        CONSTS::ACCESS_MODE_WRITER | CONSTS::OPTION_JEMALLOC, false);
-    DB initial_db(initial_cfg);
-    ASSERT_TRUE(initial_db.is_open());
-    ASSERT_EQ(initial_db.Add(key, value), MBError::SUCCESS);
-    ASSERT_EQ(initial_db.Count(), 1);
-    initial_db.Close();
-
-    MBConfig reopen_cfg = MakeJemallocRebuildConfig(
-        CONSTS::ACCESS_MODE_WRITER | CONSTS::OPTION_JEMALLOC, false);
-    DB reopen_db(reopen_cfg);
+    DB reopen_db(config);
     ASSERT_TRUE(reopen_db.is_open());
-
-    IndexHeader* header = reopen_db.GetDictPtr()->GetHeaderPtr();
-    ASSERT_NE(header, nullptr);
-    EXPECT_EQ(header->rebuild_state, REBUILD_STATE_NORMAL);
-    EXPECT_FALSE(header->RebuildInProgress());
     EXPECT_EQ(reopen_db.Count(), 0);
+    ExpectMissing(reopen_db, "existing");
+}
 
-    MBData data;
-    EXPECT_EQ(reopen_db.Find(key, data), MBError::NOT_EXIST);
-    reopen_db.Close();
+TEST_F(JemallocRebuildMetadataTest, StartupShrinkCapturesCurrentJemallocTailsInRuntimeState)
+{
+    MBConfig config = MakeSizedJemallocRebuildConfig(
+        CONSTS::ACCESS_MODE_WRITER | CONSTS::OPTION_JEMALLOC, true, 512 * 1024, 8);
+    DB writer_db(config);
+    ASSERT_TRUE(writer_db.is_open());
+    PopulateAndFragment(writer_db, 512, 4096);
+
+    ResourceCollectionTestPeer rc(writer_db);
+    rc.ResetStartupRebuildState(REBUILD_STATE_PREP);
+    ASSERT_EQ(rc.StartupShrink(), MBError::SUCCESS);
+
+    const auto& state = rc.GetStartupRebuildState();
+    auto* header = writer_db.GetDictPtr()->GetHeaderPtr();
+    ASSERT_NE(header, nullptr);
+    EXPECT_EQ(state.rebuild_state, REBUILD_STATE_COPY);
+    EXPECT_EQ(state.rebuild_index_alloc_end, header->m_index_offset);
+    EXPECT_EQ(state.rebuild_data_alloc_end, header->m_data_offset);
+    EXPECT_GE(state.rebuild_index_source_end, state.rebuild_index_alloc_end);
+    EXPECT_GE(state.rebuild_data_source_end, state.rebuild_data_alloc_end);
+}
+
+TEST_F(JemallocRebuildMetadataTest, StartupShrinkRejectsNonJemallocWriterGracefully)
+{
+    MBConfig config = MakeJemallocRebuildConfig(CONSTS::ACCESS_MODE_WRITER, false);
+    DB writer_db(config);
+    ASSERT_TRUE(writer_db.is_open());
+    ResourceCollectionTestPeer rc(writer_db);
+    rc.ResetStartupRebuildState(REBUILD_STATE_PREP);
+    EXPECT_EQ(rc.StartupShrink(), MBError::NOT_ALLOWED);
+}
+
+TEST_F(JemallocRebuildMetadataTest, StartupEvacuateAdvancesRuntimeState)
+{
+    MBConfig config = MakeSizedJemallocRebuildConfig(
+        CONSTS::ACCESS_MODE_WRITER | CONSTS::OPTION_JEMALLOC, true, 512 * 1024, 8);
+    DB writer_db(config);
+    ASSERT_TRUE(writer_db.is_open());
+    PopulateAndFragment(writer_db, 512, 4096);
+
+    ResourceCollectionTestPeer rc(writer_db);
+    rc.ResetStartupRebuildState(REBUILD_STATE_PREP);
+    ASSERT_EQ(rc.StartupShrink(), MBError::SUCCESS);
+    ASSERT_EQ(rc.StartupEvacuate(), MBError::SUCCESS);
+
+    const auto& state = rc.GetStartupRebuildState();
+    EXPECT_EQ(state.rebuild_state, REBUILD_STATE_CUTOVER);
+    EXPECT_GE(state.rebuild_index_block_cursor, 0u);
+    EXPECT_GE(state.rebuild_data_block_cursor, 0u);
+    EXPECT_GE(state.rebuild_index_source_end, state.rebuild_index_alloc_end);
+    EXPECT_GE(state.rebuild_data_source_end, state.rebuild_data_alloc_end);
+}
+
+TEST_F(JemallocRebuildMetadataTest, StartupEvacuateRejectsEmptySourceWindowGracefully)
+{
+    MBConfig config = MakeSizedJemallocRebuildConfig(
+        CONSTS::ACCESS_MODE_WRITER | CONSTS::OPTION_JEMALLOC, true, 512 * 1024, 8);
+    DB writer_db(config);
+    ASSERT_TRUE(writer_db.is_open());
+    ResourceCollectionTestPeer rc(writer_db);
+    rc.ResetStartupRebuildState(REBUILD_STATE_COPY);
+    auto& state = const_cast<StartupRebuildRuntimeState&>(rc.GetStartupRebuildState());
+    state.rebuild_index_alloc_end = writer_db.GetDictPtr()->GetHeaderPtr()->index_block_size + 1;
+    state.rebuild_data_alloc_end = writer_db.GetDictPtr()->GetHeaderPtr()->data_block_size + 1;
+    state.rebuild_index_source_end = writer_db.GetDictPtr()->GetHeaderPtr()->index_block_size;
+    state.rebuild_data_source_end = writer_db.GetDictPtr()->GetHeaderPtr()->data_block_size;
+    EXPECT_EQ(rc.StartupEvacuate(), MBError::INVALID_SIZE);
 }


### PR DESCRIPTION
Summary
This change simplifies jemalloc startup rebuild metadata by removing detailed persisted rebuild progress from IndexHeader and keeping only the state needed for the current model:

a single persisted rebuild_active marker
shared reader epoch tracking state
persisted jemalloc free-floor boundaries
The startup rebuild path is now best-effort:

if a previous rebuild was interrupted, the next writer starts from a fresh DB state instead of trying to resume partial rebuild progress
in jemalloc mode, if excep_updating_status is already set at startup, reopen skips recovery and resets to a fresh state