### PR TITLE
Harden Mabain concurrency and error handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 tags
+/build/
 doc/*
 **/*.o
 src/*.so
@@ -10,5 +11,20 @@ data/*
 src/test/key_list*
 src/test/mb_test*
 src/test/jemalloc_restart_rebuild_test_local
+/src/test/errno95_db_writer_test
+/src/test/find_lower_bound_concurrency_test
+/src/test/hashmap_lookup_bench
+/src/test/jemalloc_restart_rebuild_test
+/src/test/jemalloc_test
+/src/test/mb_bound_test
+/src/test/mb_header_test
+/src/test/mb_mm_prune_test
+/src/test/mb_mm_test
+/src/test/multi_writer_bug_test
+/src/test/prefix_cache_snapshot_concurrency_test
+/src/test/shared_prefix_cache_concurrency_test
+/src/test/shmq_queue_full_stress_test
+/src/test/shmq_reservation_timeout_test
+/src/test/sigbus_disk_pressure_test
 src/test/run_test*
 tmp/*

--- a/src/async_writer.cpp
+++ b/src/async_writer.cpp
@@ -48,7 +48,10 @@ AsyncWriter::AsyncWriter(DB* db_ptr)
     , tid(0)
     , stop_processing(false)
     , queue(NULL)
+    , reservation_time_ms(NULL)
     , header(NULL)
+    , reservation_timeout_ms(
+          static_cast<uint64_t>(CONSTS::DEFAULT_ASYNC_QUEUE_RESERVATION_TIMEOUT_SEC) * 1000)
 {
     dict = NULL;
     if (!(db_ptr->GetDBOptions() & CONSTS::ACCESS_MODE_WRITER))
@@ -64,6 +67,11 @@ AsyncWriter::AsyncWriter(DB* db_ptr)
     if (header == NULL)
         throw (int)MBError::NOT_INITIALIZED;
     queue = dict->GetAsyncQueuePtr();
+    reservation_time_ms = dict->GetAsyncQueueReservationTimePtr();
+    MBConfig config = { 0 };
+    db->GetDBConfig(config);
+    reservation_timeout_ms
+        = static_cast<uint64_t>(config.async_queue_reservation_timeout_sec) * 1000;
     header->rc_flag.store(0, std::memory_order_release);
 
     rc_backup_dir = NULL;
@@ -81,7 +89,7 @@ AsyncWriter::~AsyncWriter()
 
 int AsyncWriter::StopAsyncThread()
 {
-    stop_processing = true;
+    stop_processing.store(true, std::memory_order_relaxed);
     dict->SHMQ_Signal();
 
     if (tid != 0) {
@@ -102,7 +110,8 @@ int AsyncWriter::ProcessTask(int ntasks, bool rc_mode)
     int count = 0;
 
     while (count < ntasks) {
-        node_ptr = &queue[header->writer_index % header->async_queue_size];
+        uint32_t writer_index = header->writer_index.load(std::memory_order_relaxed);
+        node_ptr = &queue[writer_index % header->async_queue_size];
 
         if (node_ptr->in_use.load(std::memory_order_consume)) {
             switch (node_ptr->type) {
@@ -120,14 +129,15 @@ int AsyncWriter::ProcessTask(int ntasks, bool rc_mode)
                 }
                 break;
             case MABAIN_ASYNC_TYPE_REMOVE:
-                // FIXME
-                // Removing entries during rc is currently not supported.
-                // The index or data index could have been reset in fucntion ResourceColletion::Finish.
-                // However, the deletion may be run for some entry which still exist in the rc root tree.
-                // This requires modifying buffer in high end, where the offset for writing is greather than
-                // header->m_index_offset. This causes exception thrown from DictMem::WriteData.
-                // Note this is not a problem for Dict::Add since Add does not modify buffers in high end.
-                // This problem will be fixed when resolving issue: https://github.com/chxdeng/mabain/issues/21
+                // Removing entries during resource collection is currently unsupported.
+                // This task is intentionally acknowledged and discarded: the queue
+                // slot is released below, but the key remains in the database.
+                // ResourceCollection::Finish may already have reset the index or data
+                // offset while the key still exists in the resource-collection root
+                // tree. Removing it here could then write beyond header->m_index_offset
+                // and cause DictMem::WriteData to throw. Dict::Add does not have this
+                // problem because it does not modify buffers in the high end.
+                // See https://github.com/chxdeng/mabain/issues/21.
                 rval = MBError::SUCCESS;
                 break;
             case MABAIN_ASYNC_TYPE_REMOVE_ALL:
@@ -164,10 +174,13 @@ int AsyncWriter::ProcessTask(int ntasks, bool rc_mode)
                 break;
             }
 
-            header->writer_index++;
+            uint32_t slot_index = writer_index % header->async_queue_size;
+            reservation_time_ms[slot_index].store(0, std::memory_order_release);
             node_ptr->num_reader.store(0, std::memory_order_release);
             node_ptr->type = MABAIN_ASYNC_TYPE_NONE;
             node_ptr->in_use.store(false, std::memory_order_release);
+            // Publish capacity only after this physical slot is fully free.
+            header->writer_index.store(writer_index + 1, std::memory_order_release);
             mbd.Clear();
             count++;
         } else {
@@ -181,26 +194,9 @@ int AsyncWriter::ProcessTask(int ntasks, bool rc_mode)
         }
     }
 
-    if (stop_processing)
+    if (stop_processing.load(std::memory_order_relaxed))
         return MBError::RC_SKIPPED;
     return MBError::SUCCESS;
-}
-
-uint32_t AsyncWriter::NextShmSlot(uint32_t windex, uint32_t qindex)
-{
-    int cnt = 0;
-    while (windex != qindex) {
-        if (queue[windex % header->async_queue_size].in_use.load(std::memory_order_consume))
-            break;
-        if (++cnt > header->async_queue_size) {
-            windex = qindex;
-            break;
-        }
-
-        windex++;
-    }
-
-    return windex;
 }
 
 void* AsyncWriter::async_writer_thread()
@@ -223,27 +219,61 @@ void* AsyncWriter::async_writer_thread()
         writer_lock.unlock();
     }
 
-    while (!stop_processing) {
-        node_ptr = &queue[header->writer_index % header->async_queue_size];
+    while (!stop_processing.load(std::memory_order_relaxed)) {
+        uint32_t writer_index = header->writer_index.load(std::memory_order_relaxed);
+        node_ptr = &queue[writer_index % header->async_queue_size];
 
         skip = false;
         while (!node_ptr->in_use.load(std::memory_order_consume)) {
-            if (stop_processing) {
+            if (stop_processing.load(std::memory_order_relaxed)) {
                 skip = true;
                 break;
             }
 
-#define __ASYNC_THREAD_SLEEP_TIME 1000
-            mbp.Wait(__ASYNC_THREAD_SLEEP_TIME);
-
-            auto windex = header->writer_index;
+            auto windex = header->writer_index.load(std::memory_order_relaxed);
             auto qindex = header->queue_index.load(std::memory_order_consume);
-            if (windex != qindex) {
-                // Reader process may have exited unexpectedly. Recover index.
-                skip = true;
-                header->writer_index = NextShmSlot(windex, qindex);
-                break;
+            if (windex == qindex) {
+                mbp.Wait(1000);
+                continue;
             }
+
+            uint32_t slot_index = windex % header->async_queue_size;
+            uint16_t reservation = node_ptr->num_reader.load(std::memory_order_acquire);
+            uint64_t now = SHMQ_GetMonotonicTimeMs();
+            uint64_t reserved_at = reservation_time_ms[slot_index].load(std::memory_order_acquire);
+            if (reserved_at == 0 || now < reserved_at) {
+                reservation_time_ms[slot_index].store(now, std::memory_order_release);
+                reserved_at = now;
+            }
+
+            uint64_t elapsed = now - reserved_at;
+            uint64_t timeout_ms = reservation_timeout_ms;
+            if (elapsed < timeout_ms) {
+                uint64_t remaining = timeout_ms - elapsed;
+                mbp.Wait(static_cast<int>(remaining > 1000 ? 1000 : remaining));
+                continue;
+            }
+
+            // The producer may have published while the timeout check was in
+            // progress. Let the normal processing path consume it in that case.
+            if (node_ptr->in_use.load(std::memory_order_acquire))
+                continue;
+
+            // The producer may also have completed the num_reader claim while
+            // the timeout check was in progress. Re-evaluate its lease then.
+            if (reservation == 0
+                && node_ptr->num_reader.load(std::memory_order_acquire) != 0) {
+                continue;
+            }
+
+            // The reservation lease expired. Clear its timestamp before making
+            // the physical slot available to another producer.
+            reservation_time_ms[slot_index].store(0, std::memory_order_release);
+            node_ptr->type = MABAIN_ASYNC_TYPE_NONE;
+            node_ptr->num_reader.store(0, std::memory_order_release);
+            header->writer_index.store(windex + 1, std::memory_order_release);
+            skip = true;
+            break;
         }
 
         if (skip)
@@ -316,10 +346,13 @@ void* AsyncWriter::async_writer_thread()
             break;
         }
 
-        header->writer_index++;
+        uint32_t slot_index = writer_index % header->async_queue_size;
+        reservation_time_ms[slot_index].store(0, std::memory_order_release);
         node_ptr->num_reader.store(0, std::memory_order_release);
         node_ptr->type = MABAIN_ASYNC_TYPE_NONE;
         node_ptr->in_use.store(false, std::memory_order_release);
+        // Publish capacity only after this physical slot is fully free.
+        header->writer_index.store(writer_index + 1, std::memory_order_release);
 
         if (rval != MBError::SUCCESS) {
             Logger::Log(LOG_LEVEL_DEBUG, "failed to run update %d: %s",

--- a/src/async_writer.h
+++ b/src/async_writer.h
@@ -19,6 +19,7 @@
 #ifndef __ASYNC_WRITER_H__
 #define __ASYNC_WRITER_H__
 
+#include <atomic>
 #include <mutex>
 #include <pthread.h>
 
@@ -48,7 +49,6 @@ private:
     AsyncNode* AcquireSlot();
     int PrepareSlot(AsyncNode* node_ptr) const;
     void* async_writer_thread();
-    uint32_t NextShmSlot(uint32_t windex, uint32_t qindex);
 
     // db pointer
     DB* db;
@@ -56,15 +56,19 @@ private:
 
     // thread id
     pthread_t tid;
-    bool stop_processing;
+    std::atomic<bool> stop_processing;
 
     AsyncNode* queue;
+    std::atomic<uint64_t>* reservation_time_ms;
     IndexHeader* header;
+    uint64_t reservation_timeout_ms;
 
     bool is_rc_running;
     char* rc_backup_dir;
 
     std::timed_mutex writer_lock;
+    // Process-local shortcut for producer handles targeting the same DB.
+    // Assumes one async-writer DB per process and that it outlives local producers.
     static AsyncWriter* writer_instance;
 };
 

--- a/src/db.cpp
+++ b/src/db.cpp
@@ -20,7 +20,6 @@
 #include <fstream>
 #include <iostream>
 #include <sstream>
-#include <sys/file.h>
 #include <sys/syscall.h>
 #include <unistd.h>
 
@@ -49,28 +48,6 @@ namespace {
 
 const uint64_t kRebuildBarrierGuardToken = static_cast<uint64_t>(-1);
 const uint32_t kReaderEpochGuardMaxStabilizeRetries = 32;
-
-int WaitForRebuildBarrierLock(int fd, int op)
-{
-    if (fd < 0)
-        return MBError::NOT_INITIALIZED;
-    while (flock(fd, op) != 0) {
-        if (errno == EINTR)
-            continue;
-        return MBError::MUTEX_ERROR;
-    }
-    return MBError::SUCCESS;
-}
-
-void UnlockRebuildBarrier(int fd)
-{
-    if (fd < 0)
-        return;
-    while (flock(fd, LOCK_UN) != 0) {
-        if (errno != EINTR)
-            break;
-    }
-}
 
 #ifdef __linux__
 bool ReadProcStartTimeFromStatPath(const std::string& stat_path, uint64_t& start_time)
@@ -152,7 +129,7 @@ int DB::Close()
         rval = status;
     }
 
-    rebuild_guard_file.reset();
+    rebuild_barrier.reset();
 
     status = MBError::DB_CLOSED;
     if (options & CONSTS::ACCESS_MODE_WRITER) {
@@ -191,7 +168,7 @@ uint64_t DB::BeginReaderEpochGuard() const
         ReaderEpochSlot& slot = header->reader_epoch_slot[i];
         uint32_t expected = 0;
         if (!slot.connect_id.compare_exchange_strong(
-                expected, slot_connect_id, MEMORY_ORDER_WRITER, MEMORY_ORDER_READER))
+                expected, slot_connect_id, std::memory_order_acq_rel, MEMORY_ORDER_READER))
             continue;
 
         slot.pid.store(static_cast<uint32_t>(getpid()), MEMORY_ORDER_WRITER);
@@ -244,43 +221,42 @@ void DB::EndReaderEpochGuard(uint64_t epoch) const
         header->reader_epoch_slot[slot_index].Clear();
 }
 
-int DB::EnsureRebuildGuardFd() const
+int DB::EnsureRebuildBarrier() const
 {
-    if (rebuild_guard_file)
+    if (rebuild_barrier)
         return MBError::SUCCESS;
     if (options & CONSTS::MEMORY_ONLY_MODE)
         return MBError::NOT_INITIALIZED;
 
-    bool map_file = false;
     const std::string header_path = mb_dir + "_mabain_h";
     const std::string pool_key = header_path + "#rebuild_guard";
-    rebuild_guard_file = ResourcePool::getInstance().OpenFileWithKey(
-        pool_key, header_path, options, 0, map_file, false);
-    if (rebuild_guard_file == NULL || !rebuild_guard_file->IsOpen())
+    rebuild_barrier = ResourcePool::getInstance().OpenRebuildBarrier(
+        pool_key, header_path, options);
+    if (rebuild_barrier == NULL || !rebuild_barrier->IsOpen())
         return MBError::OPEN_FAILURE;
     return MBError::SUCCESS;
 }
 
 int DB::AcquireRebuildBarrierShared() const
 {
-    int rval = EnsureRebuildGuardFd();
+    int rval = EnsureRebuildBarrier();
     if (rval != MBError::SUCCESS)
         return rval;
-    return WaitForRebuildBarrierLock(rebuild_guard_file->GetFD(), LOCK_SH);
+    return rebuild_barrier->LockShared();
 }
 
 void DB::ReleaseRebuildBarrierShared() const
 {
-    if (rebuild_guard_file != NULL)
-        UnlockRebuildBarrier(rebuild_guard_file->GetFD());
+    if (rebuild_barrier != NULL)
+        rebuild_barrier->UnlockShared();
 }
 
 int DB::AcquireRebuildBarrierExclusive() const
 {
-    int rval = EnsureRebuildGuardFd();
+    int rval = EnsureRebuildBarrier();
     if (rval != MBError::SUCCESS)
         return rval;
-    return WaitForRebuildBarrierLock(rebuild_guard_file->GetFD(), LOCK_EX);
+    return rebuild_barrier->LockExclusive();
 }
 
 uint64_t DB::GetReaderGuardFastSlotCount() const
@@ -295,8 +271,8 @@ uint64_t DB::GetReaderGuardBarrierFallbackCount() const
 
 void DB::ReleaseRebuildBarrierExclusive() const
 {
-    if (rebuild_guard_file != NULL)
-        UnlockRebuildBarrier(rebuild_guard_file->GetFD());
+    if (rebuild_barrier != NULL)
+        rebuild_barrier->UnlockExclusive();
 }
 
 // Constructor for initializing DB handle
@@ -306,11 +282,16 @@ DB::DB(const char* db_path,
     size_t memcap_data,
     uint32_t id,
     uint32_t queue_size)
-    : status(MBError::NOT_INITIALIZED)
-    , rebuild_guard_file(NULL)
+    : options(0)
+    , dict(NULL)
+    , status(MBError::NOT_INITIALIZED)
+    , identifier(0)
+    , rebuild_barrier(NULL)
     , process_start_time(0)
     , reader_guard_fast_slot_count(0)
     , reader_guard_barrier_fallback_count(0)
+    , dbConfig {}
+    , async_writer(NULL)
     , writer_lock_fd(-1)
 {
     MBConfig config;
@@ -326,11 +307,16 @@ DB::DB(const char* db_path,
 }
 
 DB::DB(MBConfig& config)
-    : status(MBError::NOT_INITIALIZED)
-    , rebuild_guard_file(NULL)
+    : options(0)
+    , dict(NULL)
+    , status(MBError::NOT_INITIALIZED)
+    , identifier(0)
+    , rebuild_barrier(NULL)
     , process_start_time(0)
     , reader_guard_fast_slot_count(0)
     , reader_guard_barrier_fallback_count(0)
+    , dbConfig {}
+    , async_writer(NULL)
     , writer_lock_fd(-1)
 {
     InitDB(config);
@@ -388,6 +374,10 @@ int DB::ValidateConfig(MBConfig& config)
         std::cerr << "async queue size exceeds maximum\n";
     if (config.queue_size == 0 || config.queue_size > MB_MAX_NUM_SHM_QUEUE_NODE)
         config.queue_size = MB_MAX_NUM_SHM_QUEUE_NODE;
+    if (config.async_queue_reservation_timeout_sec == 0) {
+        config.async_queue_reservation_timeout_sec
+            = CONSTS::DEFAULT_ASYNC_QUEUE_RESERVATION_TIMEOUT_SEC;
+    }
 #ifdef __APPLE__
     if (config.queue_dir == nullptr)
         config.queue_dir = config.mbdir;
@@ -828,11 +818,16 @@ int DB::Status() const
 }
 
 DB::DB(const DB& db)
-    : status(MBError::NOT_INITIALIZED)
-    , rebuild_guard_file(NULL)
+    : options(0)
+    , dict(NULL)
+    , status(MBError::NOT_INITIALIZED)
+    , identifier(0)
+    , rebuild_barrier(NULL)
     , process_start_time(0)
     , reader_guard_fast_slot_count(0)
     , reader_guard_barrier_fallback_count(0)
+    , dbConfig {}
+    , async_writer(NULL)
     , writer_lock_fd(-1)
 {
     MBConfig db_config = db.dbConfig;
@@ -851,7 +846,7 @@ const DB& DB::operator=(const DB& db)
     MBConfig db_config = db.dbConfig;
     db_config.mbdir = db.mb_dir.c_str();
     status = MBError::NOT_INITIALIZED;
-    rebuild_guard_file.reset();
+    rebuild_barrier.reset();
     process_start_time = 0;
     reader_guard_fast_slot_count = 0;
     reader_guard_barrier_fallback_count = 0;
@@ -1004,6 +999,11 @@ int DB::Add(const char* key, int len, MBData& mbdata, bool overwrite)
         return MBError::INVALID_ARG;
     if (status != MBError::SUCCESS)
         return MBError::NOT_INITIALIZED;
+    if (mbdata.buff == NULL)
+        return MBError::INVALID_ARG;
+    if (len <= 0 || len > CONSTS::MAX_KEY_LENGHTH
+        || mbdata.data_len <= 0 || mbdata.data_len > CONSTS::MAX_DATA_SIZE)
+        return MBError::OUT_OF_BOUND;
 
     if (async_writer == NULL && (options & CONSTS::ACCESS_MODE_WRITER)) {
         rval = dict->Add(reinterpret_cast<const uint8_t*>(key), len, mbdata, overwrite);

--- a/src/db.h
+++ b/src/db.h
@@ -40,6 +40,7 @@ class LockFree;
 class AsyncWriter;
 class ResourceCollection;
 class MmapFileIO;
+class RebuildBarrier;
 struct _DBTraverseNode;
 
 typedef struct _MBConfig {
@@ -62,6 +63,10 @@ typedef struct _MBConfig {
 
     // Jemalloc configuration
     bool jemalloc_keep_db; // If true, don't call RemoveAll in jemalloc mode
+
+    // Unpublished async reservations older than this many seconds are reclaimed.
+    // Zero selects DEFAULT_ASYNC_QUEUE_RESERVATION_TIMEOUT_SEC.
+    uint32_t async_queue_reservation_timeout_sec;
 } MBConfig;
 
 // Database handle class
@@ -229,7 +234,7 @@ public:
 private:
     uint64_t BeginReaderEpochGuard() const;
     void EndReaderEpochGuard(uint64_t epoch) const;
-    int EnsureRebuildGuardFd() const;
+    int EnsureRebuildBarrier() const;
     int AcquireRebuildBarrierShared() const;
     void ReleaseRebuildBarrierShared() const;
     int AcquireRebuildBarrierExclusive() const;
@@ -254,7 +259,7 @@ private:
 
     // DB connector ID
     uint32_t identifier;
-    mutable std::shared_ptr<MmapFileIO> rebuild_guard_file;
+    mutable std::shared_ptr<RebuildBarrier> rebuild_barrier;
     uint64_t process_start_time;
     mutable uint64_t reader_guard_fast_slot_count;
     mutable uint64_t reader_guard_barrier_fallback_count;

--- a/src/detail/search_engine.cpp
+++ b/src/detail/search_engine.cpp
@@ -362,7 +362,13 @@ namespace {
         bool use_cache = true
             && !(dict.reader_rc_off != 0 && root_off == dict.reader_rc_off)
             && !(data.options & CONSTS::OPTION_FIND_AND_STORE_PARENT);
-        bool used_cache = use_cache ? seedFromCache(key, len, edge_ptrs, data, key_cursor, len, consumed) : false;
+        bool cache_retry = false;
+        bool used_cache = use_cache
+            ? seedFromCache(key, len, edge_ptrs, data, key_cursor, len, consumed,
+                cache_retry)
+            : false;
+        if (cache_retry)
+            return MBError::TRY_AGAIN;
 
         if (!used_cache) {
             rval = dict.mm.GetRootEdge(root_off, key[0], edge_ptrs);

--- a/src/detail/search_engine.h
+++ b/src/detail/search_engine.h
@@ -84,7 +84,8 @@ namespace detail {
         // key_cursor/len_remaining/consumed accordingly. For very short keys
         // (len < 2) it returns false without making a virtual call.
         inline bool seedFromCache(const uint8_t* key, int len, EdgePtrs& edge_ptrs,
-            MBData& data, const uint8_t*& key_cursor, int& len_remaining, int& consumed) const;
+            MBData& data, const uint8_t*& key_cursor, int& len_remaining, int& consumed,
+            bool& retry) const;
         // declared once above
 
         // Lower-bound internals
@@ -196,8 +197,10 @@ namespace detail {
     }
 
     inline bool SearchEngine::seedFromCache(const uint8_t* key, int len, EdgePtrs& edge_ptrs,
-        MBData& data, const uint8_t*& key_cursor, int& len_remaining, int& consumed) const
+        MBData& data, const uint8_t*& key_cursor, int& len_remaining, int& consumed,
+        bool& retry) const
     {
+        retry = false;
         // Keys shorter than 2 bytes cannot hit the cache; avoid virtual call.
         if (len < 2 || key == nullptr)
             return false;
@@ -208,6 +211,10 @@ namespace detail {
 
         PrefixCacheEntry entry;
         int n = pc->GetDepth(key, len, entry);
+        if (n == PrefixCache::UNSTABLE) {
+            retry = true;
+            return false;
+        }
         if (n == 0)
             return false;
 

--- a/src/dict.cpp
+++ b/src/dict.cpp
@@ -137,14 +137,12 @@ Dict::Dict(const std::string& mbdir, bool init_header, int datasize,
     }
     // Instantiate the prefix cache only if the DB has an embedded cache region
     // and the caller requested prefix cache via OPTION_PREFIX_CACHE.
-    if (!(options & CONSTS::ASYNC_WRITER_MODE)) {
-        bool want_cache = (header->pfxcache_size > 0) && (options & CONSTS::OPTION_PREFIX_CACHE);
-        if (want_cache) {
-            try {
-                prefix_cache = std::unique_ptr<PrefixCache>(new PrefixCache(mbdir_, header, /*capacity hint*/65536));
-            } catch (...) {
-                // Leave cache disabled on failure; DB remains operational.
-            }
+    bool want_cache = (header->pfxcache_size > 0) && (options & CONSTS::OPTION_PREFIX_CACHE);
+    if (want_cache) {
+        try {
+            prefix_cache = std::unique_ptr<PrefixCache>(new PrefixCache(mbdir_, header, /*capacity hint*/65536));
+        } catch (...) {
+            // Leave cache disabled on failure; DB remains operational.
         }
     }
     if (mm.IsValid())
@@ -183,8 +181,11 @@ void Dict::InitEmbeddedPrefixCacheLayout()
         size_t t4 = sizeof(PrefixCacheEntry) * (c4 ? c4 : 1);
         size_t g4 = sizeof(uint32_t) * (c4 ? c4 : 1);
         size_t v4 = sizeof(uint32_t) * (c4 ? c4 : 1);
-        // PCShmHeader: magic(u32) + version(u16) + reserved(u16) + 6*u32(caps/masks)
-        return sizeof(uint32_t) + sizeof(uint16_t) + sizeof(uint16_t) + 6 * sizeof(uint32_t)
+        // PCShmHeader plus O(1) invalidation epochs for global, first-byte,
+        // and two-byte scopes. The first global epoch lives in the header.
+        size_t epoch_bytes = (NUM_ALPHABET + (1u << 16)) * sizeof(uint32_t);
+        return sizeof(uint32_t) + sizeof(uint16_t) + sizeof(uint16_t) + 8 * sizeof(uint32_t)
+            + epoch_bytes
             + g2 + t2 + g3 + t3 + v4 + g4 + t4;
     };
 
@@ -309,6 +310,8 @@ int Dict::Add(const uint8_t* key, int len, MBData& data, bool overwrite)
             header->count++;
             header->num_update++;
         }
+        if (prefix_cache)
+            SeedCanonicalBoundariesAfterAdd(key, len);
         return MBError::SUCCESS;
     }
 
@@ -394,12 +397,12 @@ int Dict::Add(const uint8_t* key, int len, MBData& data, bool overwrite)
     }
     // After a successful add, seed prefix cache at canonical 2/3-byte boundaries.
     if (rval == MBError::SUCCESS && prefix_cache) {
-        SeedCanonicalBoundariesAfterAdd(key, orig_len, /*from_add=*/true);
+        SeedCanonicalBoundariesAfterAdd(key, orig_len);
     }
     return rval;
 }
 
-void Dict::SeedCanonicalBoundariesAfterAdd(const uint8_t* key, int len, bool from_add) const
+void Dict::SeedCanonicalBoundariesAfterAdd(const uint8_t* key, int len) const
 {
     if (!prefix_cache)
         return;
@@ -417,6 +420,25 @@ void Dict::SeedCanonicalBoundariesAfterAdd(const uint8_t* key, int len, bool fro
     int remain = len;
     int consumed = 0;
     uint8_t tmp_key_buff[NUM_ALPHABET];
+
+    // Seed every canonical boundary crossed by a compressed edge. Previously
+    // only the 4-byte mid-edge case was handled, so long edges could leave the
+    // 2/3-byte tables empty even though the writer had a complete path.
+    auto seed_crossed_depths = [&](int before, int matched_edge_len,
+                                   const EdgePtrs& matched_edge, int max_depth) {
+        const int after = before + matched_edge_len;
+        for (int depth = 2; depth <= max_depth; ++depth) {
+            if (len < depth || before >= depth || after < depth)
+                continue;
+            PrefixCacheEntry entry {};
+            entry.edge_offset = matched_edge.offset;
+            entry.edge_skip = static_cast<uint8_t>(
+                depth == after ? 0 : depth - before);
+            entry.lf_counter = 1;
+            memcpy(entry.edge_buff, matched_edge.edge_buff, EDGE_SIZE);
+            prefix_cache->PutAtDepth(key, depth, entry);
+        }
+    };
 
     // Step 1: handle root edge like findInternal
     int edge_len = edge_ptrs.len_ptr[0];
@@ -438,78 +460,21 @@ void Dict::SeedCanonicalBoundariesAfterAdd(const uint8_t* key, int len, bool fro
 
     if (edge_len < remain) {
         if (edge_len_m1 <= 0 || memcmp(key_buff, key_cursor + 1, edge_len_m1) == 0) {
-            // If 4-byte boundary falls inside this edge and prefix matches, seed a mid-edge entry.
-            if (from_add && len >= 4 && consumed < 4 && consumed + edge_len >= 4) {
-                uint8_t skip = static_cast<uint8_t>(4 - consumed);
-                PrefixCacheEntry e {};
-                e.edge_offset = edge_ptrs.offset;
-                e.edge_skip = skip;
-                e.lf_counter = static_cast<uint32_t>(from_add ? 1 : 2);
-                memcpy(e.edge_buff, edge_ptrs.edge_buff, EDGE_SIZE);
-                prefix_cache->PutAtDepth(key, 4, e);
-            }
+            seed_crossed_depths(consumed, edge_len, edge_ptrs, 4);
             key_cursor += edge_len;
             consumed += edge_len;
             remain -= edge_len;
-            if (remain <= 0) {
-                // final match at root: seed at consumed depth
-                if (consumed == 4) {
-                    PrefixCacheEntry e {};
-                    e.edge_offset = edge_ptrs.offset;
-                    e.edge_skip = 0;
-                    e.lf_counter = static_cast<uint32_t>(from_add ? 1 : 2);
-                    memcpy(e.edge_buff, edge_ptrs.edge_buff, EDGE_SIZE);
-                    prefix_cache->PutAtDepth(key, 4, e);
-                } else if (consumed == 3) {
-                    PrefixCacheEntry e {};
-                    e.edge_offset = edge_ptrs.offset;
-                    e.edge_skip = 0;
-                    e.lf_counter = static_cast<uint32_t>(from_add ? 1 : 2);
-                    memcpy(e.edge_buff, edge_ptrs.edge_buff, EDGE_SIZE);
-                    prefix_cache->PutAtDepth(key, 3, e);
-                } else if (consumed == 2) {
-                    PrefixCacheEntry e2 {};
-                    e2.edge_offset = edge_ptrs.offset;
-                    e2.edge_skip = 0;
-                    e2.lf_counter = static_cast<uint32_t>(from_add ? 1 : 2);
-                    memcpy(e2.edge_buff, edge_ptrs.edge_buff, EDGE_SIZE);
-                    prefix_cache->PutAtDepth(key, 2, e2);
-                }
+            if (remain <= 0)
                 return;
-            }
             if (edge_ptrs.flag_ptr[0] & EDGE_FLAG_DATA_OFF)
                 return; // leaf
-            // Defer seeding at this consumed depth until we've loaded the
-            // next edge (so cache stores the correct traversal state).
         } else {
             return;
         }
     } else if (edge_len == remain) {
         if (edge_len_m1 <= 0 || memcmp(key_buff, key_cursor + 1, edge_len_m1) == 0) {
-            // mirror find: seed at final depth (consumed + edge_len)
-            int c = consumed + edge_len;
-            if (c == 4) {
-                PrefixCacheEntry e {};
-                e.edge_offset = edge_ptrs.offset;
-                e.edge_skip = 0;
-                e.lf_counter = static_cast<uint32_t>(from_add ? 1 : 2);
-                memcpy(e.edge_buff, edge_ptrs.edge_buff, EDGE_SIZE);
-                prefix_cache->PutAtDepth(key, 4, e);
-            } else if (c == 3) {
-                PrefixCacheEntry e {};
-                e.edge_offset = edge_ptrs.offset;
-                e.edge_skip = 0;
-                e.lf_counter = static_cast<uint32_t>(from_add ? 1 : 2);
-                memcpy(e.edge_buff, edge_ptrs.edge_buff, EDGE_SIZE);
-                prefix_cache->PutAtDepth(key, 3, e);
-            } else if (c == 2) {
-                PrefixCacheEntry e2 {};
-                e2.edge_offset = edge_ptrs.offset;
-                e2.edge_skip = 0;
-                e2.lf_counter = static_cast<uint32_t>(from_add ? 1 : 2);
-                memcpy(e2.edge_buff, edge_ptrs.edge_buff, EDGE_SIZE);
-                prefix_cache->PutAtDepth(key, 2, e2);
-            }
+            // This may be a long final root edge, so seed every crossed depth.
+            seed_crossed_depths(consumed, edge_len, edge_ptrs, 4);
         }
         return;
     } else {
@@ -542,94 +507,15 @@ void Dict::SeedCanonicalBoundariesAfterAdd(const uint8_t* key, int len, bool fro
         if (edge_len_m1 > 0 && memcmp(key_buff, key_cursor + 1, edge_len_m1) != 0) {
             break;
         }
-        // If 4-byte boundary falls inside this edge and prefix matches, seed mid-edge entry.
-        if (from_add && len >= 4 && consumed < 4 && consumed + edge_len >= 4) {
-            uint8_t skip = static_cast<uint8_t>(4 - consumed);
-            PrefixCacheEntry e {};
-            e.edge_offset = edge_ptrs.offset;
-            e.edge_skip = skip;
-            e.lf_counter = static_cast<uint32_t>(from_add ? 1 : 2);
-            memcpy(e.edge_buff, edge_ptrs.edge_buff, EDGE_SIZE);
-            prefix_cache->PutAtDepth(key, 4, e);
-        }
+        seed_crossed_depths(consumed, edge_len, edge_ptrs, 4);
         // advance
         remain -= edge_len;
-        if (remain <= 0) {
-            int c = consumed + edge_len;
-            if (c == 4) {
-                PrefixCacheEntry e {};
-                e.edge_offset = edge_ptrs.offset;
-                e.edge_skip = 0;
-                e.lf_counter = static_cast<uint32_t>(from_add ? 1 : 2);
-                memcpy(e.edge_buff, edge_ptrs.edge_buff, EDGE_SIZE);
-                prefix_cache->PutAtDepth(key, 4, e);
-            } else if (c == 3) {
-                PrefixCacheEntry e {};
-                e.edge_offset = edge_ptrs.offset;
-                e.edge_skip = 0;
-                e.lf_counter = static_cast<uint32_t>(from_add ? 1 : 2);
-                memcpy(e.edge_buff, edge_ptrs.edge_buff, EDGE_SIZE);
-                prefix_cache->PutAtDepth(key, 3, e);
-            } else if (c == 2) {
-                PrefixCacheEntry e2 {};
-                e2.edge_offset = edge_ptrs.offset;
-                e2.edge_skip = 0;
-                e2.lf_counter = static_cast<uint32_t>(from_add ? 1 : 2);
-                memcpy(e2.edge_buff, edge_ptrs.edge_buff, EDGE_SIZE);
-                prefix_cache->PutAtDepth(key, 2, e2);
-            }
+        if (remain <= 0)
             break;
-        }
-        if (edge_ptrs.flag_ptr[0] & EDGE_FLAG_DATA_OFF) {
-            int c = consumed + edge_len;
-            if (c == 4) {
-                PrefixCacheEntry e {};
-                e.edge_offset = edge_ptrs.offset;
-                e.edge_skip = 0;
-                e.lf_counter = static_cast<uint32_t>(from_add ? 1 : 2);
-                memcpy(e.edge_buff, edge_ptrs.edge_buff, EDGE_SIZE);
-                prefix_cache->PutAtDepth(key, 4, e);
-            } else if (c == 3) {
-                PrefixCacheEntry e {};
-                e.edge_offset = edge_ptrs.offset;
-                e.edge_skip = 0;
-                e.lf_counter = static_cast<uint32_t>(from_add ? 1 : 2);
-                memcpy(e.edge_buff, edge_ptrs.edge_buff, EDGE_SIZE);
-                prefix_cache->PutAtDepth(key, 3, e);
-            } else if (c == 2) {
-                PrefixCacheEntry e2 {};
-                e2.edge_offset = edge_ptrs.offset;
-                e2.edge_skip = 0;
-                e2.lf_counter = static_cast<uint32_t>(from_add ? 1 : 2);
-                memcpy(e2.edge_buff, edge_ptrs.edge_buff, EDGE_SIZE);
-                prefix_cache->PutAtDepth(key, 2, e2);
-            }
+        if (edge_ptrs.flag_ptr[0] & EDGE_FLAG_DATA_OFF)
             break;
-        }
         key_cursor += edge_len;
         consumed += edge_len;
-        if (consumed == 4) {
-            PrefixCacheEntry e {};
-            e.edge_offset = edge_ptrs.offset;
-            e.edge_skip = 0;
-            e.lf_counter = static_cast<uint32_t>(from_add ? 1 : 2);
-            memcpy(e.edge_buff, edge_ptrs.edge_buff, EDGE_SIZE);
-            prefix_cache->PutAtDepth(key, 4, e);
-        } else if (consumed == 3) {
-            PrefixCacheEntry e {};
-            e.edge_offset = edge_ptrs.offset;
-            e.edge_skip = 0;
-            e.lf_counter = static_cast<uint32_t>(from_add ? 1 : 2);
-            memcpy(e.edge_buff, edge_ptrs.edge_buff, EDGE_SIZE);
-            prefix_cache->PutAtDepth(key, 3, e);
-        } else if (consumed == 2) {
-            PrefixCacheEntry e2 {};
-            e2.edge_offset = edge_ptrs.offset;
-            e2.edge_skip = 0;
-            e2.lf_counter = static_cast<uint32_t>(from_add ? 1 : 2);
-            memcpy(e2.edge_buff, edge_ptrs.edge_buff, EDGE_SIZE);
-            prefix_cache->PutAtDepth(key, 2, e2);
-        }
     }
 }
 
@@ -938,6 +824,38 @@ int Dict::Remove(const uint8_t* key, int len)
     return Remove(key, len, data);
 }
 
+bool Dict::RemovalChangesMultiplePrefix2(uint8_t first_byte,
+    const EdgePtrs& edge_ptrs) const
+{
+    EdgePtrs root_edge;
+    if (mm.GetRootEdge(0, first_byte, root_edge) != MBError::SUCCESS)
+        return true; // Conservatively invalidate the first-byte scope.
+
+    // The first byte selects a fixed root slot. Only a one-byte, non-leaf root
+    // edge can lead directly to a node whose children have different second
+    // bytes. Rebuilding that node moves sibling edges across prefix2 groups.
+    if (root_edge.len_ptr[0] != 1
+        || (root_edge.flag_ptr[0] & EDGE_FLAG_DATA_OFF))
+        return false;
+
+    return edge_ptrs.curr_node_offset
+        == Get6BInteger(root_edge.offset_ptr);
+}
+
+void Dict::InvalidatePrefixCacheForRemove(const uint8_t* key, int len,
+    const EdgePtrs& edge_ptrs, bool structural_change) const
+{
+    if (!prefix_cache || key == nullptr || len < 2)
+        return;
+
+    if (structural_change
+        && RemovalChangesMultiplePrefix2(key[0], edge_ptrs)) {
+        prefix_cache->InvalidateRoot(key[0]);
+    } else {
+        prefix_cache->InvalidatePrefix2(key, len);
+    }
+}
+
 int Dict::Remove(const uint8_t* key, int len, MBData& data)
 {
     if (!(options & CONSTS::ACCESS_MODE_WRITER)) {
@@ -952,12 +870,15 @@ int Dict::Remove(const uint8_t* key, int len, MBData& data)
     if (!(data.options & CONSTS::OPTION_FIND_AND_STORE_PARENT))
         return MBError::INVALID_ARG;
 
+    const int orig_len = len;
     int rval;
     {
         detail::SearchEngine engine(*this);
         rval = engine.find(key, len, data);
     }
     if (rval == MBError::IN_DICT) {
+        InvalidatePrefixCacheForRemove(key, orig_len, data.edge_ptrs,
+            (data.edge_ptrs.flag_ptr[0] & EDGE_FLAG_DATA_OFF) != 0);
         rval = DeleteDataFromEdge(data, data.edge_ptrs);
         while (rval == MBError::TRY_AGAIN) {
             data.Clear();
@@ -970,6 +891,8 @@ int Dict::Remove(const uint8_t* key, int len, MBData& data)
                 rval = engine.find(key, len, data);
             }
             if (MBError::IN_DICT == rval) {
+                InvalidatePrefixCacheForRemove(key, orig_len, data.edge_ptrs,
+                    true);
                 rval = mm.RemoveEdgeByIndex(data.edge_ptrs, data);
             }
         }
@@ -986,10 +909,23 @@ int Dict::RemoveAll()
 {
     int rval = MBError::SUCCESS;
 
+    if (prefix_cache)
+        prefix_cache->InvalidateAll();
+
     mm.ClearMem(); // clear memory will re-initialize jemalloc
     if (options & CONSTS::OPTION_JEMALLOC) {
         mm.InitRootNode();
-        kv_file->ResetJemalloc();
+        const int reset_rval = kv_file->ResetJemalloc();
+        if (reset_rval == MBError::SUCCESS && header->pfxcache_size > 0) {
+            // The embedded cache occupies the beginning of data block 0. A
+            // successful reset rewinds jemalloc's cursor, so restore the
+            // user-data allocation floor before any post-RemoveAll Add can
+            // reuse cache storage. Preserve the existing behavior when this
+            // handle does not own the arena and ResetJemalloc is not allowed.
+            rval = kv_file->ReseedJemalloc(GetStartDataOffset());
+            if (rval != MBError::SUCCESS)
+                return rval;
+        }
         for (int c = 0; c < NUM_ALPHABET; c++) {
             rval = mm.ClearRootEdge(c);
             if (rval != MBError::SUCCESS)

--- a/src/dict.cpp
+++ b/src/dict.cpp
@@ -128,7 +128,9 @@ Dict::Dict(const std::string& mbdir, bool init_header, int datasize,
 
     // In jemalloc mode, ensure the data-file arena starts after the reserved
     // embedded prefix-cache region so allocations do not overwrite cache tables.
-    if ((options & CONSTS::OPTION_JEMALLOC) && header->pfxcache_size > 0) {
+    if ((options & CONSTS::OPTION_JEMALLOC)
+        && (options & CONSTS::ACCESS_MODE_WRITER)
+        && header->pfxcache_size > 0) {
         // header->m_data_offset already points to the first user-data byte.
         // PreAlloc advances the arena's alloc_size to this offset for block 0.
         (void)kv_file->PreAlloc(header->m_data_offset);
@@ -1017,6 +1019,11 @@ pthread_mutex_t* Dict::GetShmLockPtr() const
 AsyncNode* Dict::GetAsyncQueuePtr() const
 {
     return slaq->queue;
+}
+
+std::atomic<uint64_t>* Dict::GetAsyncQueueReservationTimePtr() const
+{
+    return slaq->reservation_time_ms;
 }
 
 // Reserve buffer and write to it

--- a/src/dict.h
+++ b/src/dict.h
@@ -115,6 +115,7 @@ public:
 
     pthread_mutex_t* GetShmLockPtr() const;
     AsyncNode* GetAsyncQueuePtr() const;
+    std::atomic<uint64_t>* GetAsyncQueueReservationTimePtr() const;
 
     void UpdateNumReader(int delta) const;
     int UpdateNumWriter(int delta) const;

--- a/src/dict.h
+++ b/src/dict.h
@@ -147,6 +147,10 @@ private:
     int ReadDataFromEdge(MBData& data, const EdgePtrs& edge_ptrs) const;
     int ReadDataFromNode(MBData& data, const uint8_t* node_ptr) const;
     int DeleteDataFromEdge(MBData& data, EdgePtrs& edge_ptrs);
+    void InvalidatePrefixCacheForRemove(const uint8_t* key, int len,
+        const EdgePtrs& edge_ptrs, bool structural_change) const;
+    bool RemovalChangesMultiplePrefix2(uint8_t first_byte,
+        const EdgePtrs& edge_ptrs) const;
     int ReadNodeMatch(size_t node_off, int& match, MBData& data) const;
     int SHMQ_PrepareSlot(AsyncNode* node_ptr);
     AsyncNode* SHMQ_AcquireSlot(int& err) const;
@@ -180,7 +184,7 @@ private:
     // After a successful Add, seed cache at canonical 2/3-byte boundaries
     // using the final structure (mirrors reader warm). Applies to shared and
     // non-shared caches and detects boundary crossings within long edges.
-    void SeedCanonicalBoundariesAfterAdd(const uint8_t* key, int len, bool from_add = true) const;
+    void SeedCanonicalBoundariesAfterAdd(const uint8_t* key, int len) const;
 
     // Initialize the embedded prefix cache layout in the data file header
     // and set the starting data offset accordingly.

--- a/src/drm_base.h
+++ b/src/drm_base.h
@@ -73,17 +73,59 @@
 namespace mabain {
 
 typedef struct _ReaderEpochSlot {
+    static constexpr uint64_t RECLAIMING_PROC_START_TIME = static_cast<uint64_t>(-1);
+
     std::atomic<uint32_t> connect_id;
     std::atomic<uint32_t> pid;
     std::atomic<uint64_t> proc_start_time;
     std::atomic<uint64_t> epoch;
 
+    // The caller must first establish that the process identity represented by
+    // the expected metadata is no longer alive. Claim proc_start_time before
+    // clearing so a replacement reader cannot be erased using an old snapshot.
+    bool TryClearStale(uint32_t expected_connect_id, uint32_t expected_pid,
+        uint64_t expected_proc_start_time, uint64_t expected_epoch)
+    {
+        if (expected_connect_id == 0 || expected_pid == 0
+            || expected_proc_start_time == RECLAIMING_PROC_START_TIME)
+            return false;
+        if (connect_id.load(MEMORY_ORDER_READER) != expected_connect_id
+            || pid.load(MEMORY_ORDER_READER) != expected_pid
+            || epoch.load(MEMORY_ORDER_READER) != expected_epoch)
+            return false;
+
+        uint64_t expected = expected_proc_start_time;
+        if (!proc_start_time.compare_exchange_strong(expected,
+                RECLAIMING_PROC_START_TIME, std::memory_order_acq_rel,
+                MEMORY_ORDER_READER))
+            return false;
+
+        // Revalidate after acquiring the claim. If another owner changed the
+        // slot, restore only if the claim marker is still ours.
+        if (connect_id.load(MEMORY_ORDER_READER) != expected_connect_id
+            || pid.load(MEMORY_ORDER_READER) != expected_pid
+            || epoch.load(MEMORY_ORDER_READER) != expected_epoch) {
+            expected = RECLAIMING_PROC_START_TIME;
+            proc_start_time.compare_exchange_strong(expected,
+                expected_proc_start_time, std::memory_order_acq_rel,
+                MEMORY_ORDER_READER);
+            return false;
+        }
+
+        pid.store(0, MEMORY_ORDER_WRITER);
+        epoch.store(0, MEMORY_ORDER_WRITER);
+        proc_start_time.store(0, MEMORY_ORDER_WRITER);
+        connect_id.store(0, MEMORY_ORDER_WRITER);
+        return true;
+    }
+
     void Clear()
     {
-        connect_id.store(0, MEMORY_ORDER_WRITER);
         pid.store(0, MEMORY_ORDER_WRITER);
         proc_start_time.store(0, MEMORY_ORDER_WRITER);
         epoch.store(0, MEMORY_ORDER_WRITER);
+        // Publish the slot as free only after its previous metadata is gone.
+        connect_id.store(0, MEMORY_ORDER_WRITER);
     }
 } ReaderEpochSlot;
 
@@ -208,7 +250,7 @@ typedef struct _IndexHeader {
     // multi-process async queue
     int async_queue_size;
     std::atomic<uint32_t> queue_index;
-    uint32_t writer_index;
+    std::atomic<uint32_t> writer_index;
     std::atomic<uint32_t> rc_flag;
 
     // Embedded prefix cache (fixed capacity, set at DB initialization)

--- a/src/logger.cpp
+++ b/src/logger.cpp
@@ -129,7 +129,7 @@ void Logger::Log(int level, const char* format, ...)
     char message[256];
     va_list args;
     va_start(args, format);
-    vsprintf(message, format, args);
+    vsnprintf(message, sizeof(message), format, args);
     if (log_stream != NULL) {
         char buffer[64];
         FillDateTime(buffer, sizeof(buffer));

--- a/src/mabain_consts.cpp
+++ b/src/mabain_consts.cpp
@@ -43,6 +43,7 @@ const int CONSTS::MAX_DATA_SIZE = 0x7FFF;
 // Limit how many times readers retry when lock-free snapshot reports TRY_AGAIN
 const int CONSTS::LOCK_FREE_RETRY_LIMIT = 1000;
 const int CONSTS::FIND_TRAVERSAL_LIMIT = 1000;
+const int CONSTS::DEFAULT_ASYNC_QUEUE_RESERVATION_TIMEOUT_SEC = 3600;
 
 int CONSTS::WriterOptions()
 {

--- a/src/mabain_consts.h
+++ b/src/mabain_consts.h
@@ -29,6 +29,8 @@ public:
     static const int SYNC_ON_WRITE;
     static const int USE_SLIDING_WINDOW;
     static const int MEMORY_ONLY_MODE;
+    // Lookup-only mode: no shared async queue is attached, so queue-backed
+    // updates and the DB lock APIs are unsupported.
     static const int READ_ONLY_DB;
 
     static const int OPTION_FIND_AND_STORE_PARENT;
@@ -46,6 +48,8 @@ public:
     static const int LOCK_FREE_RETRY_LIMIT;
     // Max steps allowed in Find traversal loop to avoid pathological spins
     static const int FIND_TRAVERSAL_LIMIT;
+    // Default lease in seconds for an unpublished async queue reservation.
+    static const int DEFAULT_ASYNC_QUEUE_RESERVATION_TIMEOUT_SEC;
 
     static int WriterOptions();
     static int ReaderOptions();

--- a/src/mb_rc.cpp
+++ b/src/mb_rc.cpp
@@ -498,27 +498,30 @@ bool ResourceCollection::IsReaderEpochQuiesced(uint64_t retire_epoch) const
 
     for (uint32_t i = 0; i < header->reader_epoch_slot_count; i++) {
         ReaderEpochSlot& slot = header->reader_epoch_slot[i];
-        if (slot.connect_id.load(MEMORY_ORDER_READER) == 0)
+        const uint32_t slot_connect_id = slot.connect_id.load(MEMORY_ORDER_READER);
+        if (slot_connect_id == 0)
             continue;
         uint64_t epoch = slot.epoch.load(MEMORY_ORDER_READER);
         if (epoch != 0 && epoch <= retire_epoch) {
             uint32_t pid = slot.pid.load(MEMORY_ORDER_READER);
             if (pid != 0) {
-#ifdef __linux__
                 const uint64_t slot_start_time = slot.proc_start_time.load(MEMORY_ORDER_READER);
+#ifdef __linux__
                 uint64_t live_start_time = 0;
                 if (slot_start_time != 0 && ReadProcStartTimeForPid(static_cast<pid_t>(pid), live_start_time)) {
                     if (live_start_time != slot_start_time) {
-                        slot.Clear();
-                        continue;
+                        if (slot.TryClearStale(slot_connect_id, pid, slot_start_time, epoch))
+                            continue;
+                        return false;
                     }
                     return false;
                 }
 #endif
                 errno = 0;
                 if (kill(static_cast<pid_t>(pid), 0) != 0 && errno == ESRCH) {
-                    slot.Clear();
-                    continue;
+                    if (slot.TryClearStale(slot_connect_id, pid, slot_start_time, epoch))
+                        continue;
+                    return false;
                 }
             }
             return false;

--- a/src/resource_pool.cpp
+++ b/src/resource_pool.cpp
@@ -16,7 +16,9 @@
 
 // @author Changxue Deng <chadeng@cisco.com>
 
+#include <errno.h>
 #include <string.h>
+#include <sys/file.h>
 
 #include "error.h"
 #include "logger.h"
@@ -25,6 +27,98 @@
 #include "resource_pool.h"
 
 namespace mabain {
+
+namespace {
+
+int WaitForFileLock(int fd, int op)
+{
+    if (fd < 0)
+        return MBError::NOT_INITIALIZED;
+    while (flock(fd, op) != 0) {
+        if (errno == EINTR)
+            continue;
+        return MBError::MUTEX_ERROR;
+    }
+    return MBError::SUCCESS;
+}
+
+void UnlockFile(int fd)
+{
+    if (fd < 0)
+        return;
+    while (flock(fd, LOCK_UN) != 0) {
+        if (errno != EINTR)
+            break;
+    }
+}
+
+} // namespace
+
+RebuildBarrier::RebuildBarrier(std::shared_ptr<MmapFileIO> in_file)
+    : file(in_file)
+    , reader_count(0)
+    , waiting_writer_count(0)
+    , writer_active(false)
+{
+}
+
+bool RebuildBarrier::IsOpen() const
+{
+    return file != nullptr && file->IsOpen();
+}
+
+int RebuildBarrier::LockShared()
+{
+    std::unique_lock<std::mutex> lock(lock_mutex);
+    while (writer_active || waiting_writer_count != 0)
+        lock_cv.wait(lock);
+
+    if (reader_count == 0) {
+        int rval = WaitForFileLock(file->GetFD(), LOCK_SH);
+        if (rval != MBError::SUCCESS)
+            return rval;
+    }
+    reader_count++;
+    return MBError::SUCCESS;
+}
+
+void RebuildBarrier::UnlockShared()
+{
+    std::lock_guard<std::mutex> lock(lock_mutex);
+    if (reader_count == 0)
+        return;
+    if (--reader_count == 0) {
+        UnlockFile(file->GetFD());
+        lock_cv.notify_all();
+    }
+}
+
+int RebuildBarrier::LockExclusive()
+{
+    std::unique_lock<std::mutex> lock(lock_mutex);
+    waiting_writer_count++;
+    while (writer_active || reader_count != 0)
+        lock_cv.wait(lock);
+    waiting_writer_count--;
+    writer_active = true;
+
+    int rval = WaitForFileLock(file->GetFD(), LOCK_EX);
+    if (rval != MBError::SUCCESS) {
+        writer_active = false;
+        lock_cv.notify_all();
+    }
+    return rval;
+}
+
+void RebuildBarrier::UnlockExclusive()
+{
+    std::lock_guard<std::mutex> lock(lock_mutex);
+    if (!writer_active)
+        return;
+    UnlockFile(file->GetFD());
+    writer_active = false;
+    lock_cv.notify_all();
+}
 
 ResourcePool::ResourcePool()
 {
@@ -39,6 +133,7 @@ ResourcePool::~ResourcePool()
 void ResourcePool::RemoveAll()
 {
     pthread_mutex_lock(&pool_mutex);
+    rebuild_barrier_pool.clear();
     file_pool.clear();
     pthread_mutex_unlock(&pool_mutex);
 }
@@ -47,16 +142,17 @@ void ResourcePool::RemoveAll()
 bool ResourcePool::CheckExistence(const std::string& header_path)
 {
     pthread_mutex_lock(&pool_mutex);
-    auto search = file_pool.find(header_path);
+    bool exists = file_pool.find(header_path) != file_pool.end();
     pthread_mutex_unlock(&pool_mutex);
 
-    return (search != file_pool.end());
+    return exists;
 }
 
 void ResourcePool::RemoveResourceByPath(const std::string& path)
 {
     Logger::Log(LOG_LEVEL_DEBUG, "remove resource %s", path.c_str());
     pthread_mutex_lock(&pool_mutex);
+    rebuild_barrier_pool.erase(path);
     file_pool.erase(path);
     pthread_mutex_unlock(&pool_mutex);
 }
@@ -68,6 +164,13 @@ void ResourcePool::RemoveResourceByDB(const std::string& db_path)
     for (auto it = file_pool.begin(); it != file_pool.end();) {
         if (it->first.compare(0, db_path.size(), db_path) == 0)
             it = file_pool.erase(it);
+        else
+            it++;
+    }
+
+    for (auto it = rebuild_barrier_pool.begin(); it != rebuild_barrier_pool.end();) {
+        if (it->first.compare(0, db_path.size(), db_path) == 0)
+            it = rebuild_barrier_pool.erase(it);
         else
             it++;
     }
@@ -137,6 +240,28 @@ std::shared_ptr<MmapFileIO> ResourcePool::OpenFile(const std::string& fpath,
     bool create_file)
 {
     return OpenFileWithKey(fpath, fpath, mode, file_size, map_file, create_file);
+}
+
+std::shared_ptr<RebuildBarrier> ResourcePool::OpenRebuildBarrier(
+    const std::string& pool_key, const std::string& fpath, int mode)
+{
+    bool map_file = false;
+    std::shared_ptr<MmapFileIO> file = OpenFileWithKey(
+        pool_key, fpath, mode, 0, map_file, false);
+    if (file == nullptr || !file->IsOpen())
+        return nullptr;
+
+    pthread_mutex_lock(&pool_mutex);
+    auto search = rebuild_barrier_pool.find(pool_key);
+    std::shared_ptr<RebuildBarrier> barrier;
+    if (search == rebuild_barrier_pool.end()) {
+        barrier = std::make_shared<RebuildBarrier>(file);
+        rebuild_barrier_pool[pool_key] = barrier;
+    } else {
+        barrier = search->second;
+    }
+    pthread_mutex_unlock(&pool_mutex);
+    return barrier;
 }
 
 int ResourcePool::AddResourceByPath(const std::string& path, std::shared_ptr<MmapFileIO> resource)

--- a/src/resource_pool.h
+++ b/src/resource_pool.h
@@ -19,7 +19,10 @@
 #ifndef __RESOURCE_POOL__
 #define __RESOURCE_POOL__
 
+#include <cstdint>
+#include <condition_variable>
 #include <memory>
+#include <mutex>
 #include <pthread.h>
 #include <string>
 #include <unordered_map>
@@ -27,6 +30,27 @@
 #include "mmap_file.h"
 
 namespace mabain {
+
+// One process-local owner for the cross-process rebuild flock. Local reference
+// counting keeps one reader from releasing another reader's shared lock.
+class RebuildBarrier {
+public:
+    explicit RebuildBarrier(std::shared_ptr<MmapFileIO> file);
+
+    bool IsOpen() const;
+    int LockShared();
+    void UnlockShared();
+    int LockExclusive();
+    void UnlockExclusive();
+
+private:
+    std::shared_ptr<MmapFileIO> file;
+    std::mutex lock_mutex;
+    std::condition_variable lock_cv;
+    uint32_t reader_count;
+    uint32_t waiting_writer_count;
+    bool writer_active;
+};
 
 // A singleton class for managing resource/file descriptors using
 // shared_ptr. All db handles for the same db will share the same
@@ -43,6 +67,8 @@ public:
         const std::string& fpath, int mode,
         size_t file_size, bool& map_file,
         bool create_file);
+    std::shared_ptr<RebuildBarrier> OpenRebuildBarrier(
+        const std::string& pool_key, const std::string& fpath, int mode);
     void RemoveResourceByDB(const std::string& db_path);
     void RemoveResourceByPath(const std::string& path);
     void RemoveAll();
@@ -60,6 +86,7 @@ private:
     ResourcePool();
 
     std::unordered_map<std::string, std::shared_ptr<MmapFileIO>> file_pool;
+    std::unordered_map<std::string, std::shared_ptr<RebuildBarrier>> rebuild_barrier_pool;
     pthread_mutex_t pool_mutex;
 };
 

--- a/src/rollable_file.cpp
+++ b/src/rollable_file.cpp
@@ -59,6 +59,7 @@ RollableFile::RollableFile(const std::string& fpath, size_t blocksize, size_t me
     , mmap_mem(memcap)
     , sliding_mmap(access_mode & CONSTS::USE_SLIDING_WINDOW)
     , mode(access_mode)
+    , owns_jemalloc_arena(false)
     , max_num_block(max_block)
     , rc_offset_percentage(in_rc_offset_percentage)
     , mem_used(0)
@@ -112,7 +113,7 @@ void RollableFile::InitShmSlidingAddr(std::atomic<size_t>* shm_sliding_addr)
 
 void RollableFile::Close()
 {
-    if (mode & CONSTS::OPTION_JEMALLOC) {
+    if (owns_jemalloc_arena) {
         DestroyJemallocArena(false);
     }
     if (sliding_addr != NULL) {
@@ -151,14 +152,9 @@ int RollableFile::OpenAndMapBlockFile(size_t block_order, bool create_file)
 
     if (!map_file && (mode & CONSTS::MEMORY_ONLY_MODE))
         return MBError::NO_MEMORY;
-    bool init_jem = false;
-    if (block_order == 0 && (mode & CONSTS::OPTION_JEMALLOC)) {
-        // Check if jemalloc is initialized already
-        if (ResourcePool::getInstance().GetResourceByPath(path + "0") == nullptr) {
-            // mm_meta is only initialized for the first block
-            init_jem = true;
-        }
-    }
+    bool configure_jemalloc = block_order == 0
+        && (mode & CONSTS::OPTION_JEMALLOC)
+        && (mode & CONSTS::ACCESS_MODE_WRITER);
     files[block_order] = ResourcePool::getInstance().OpenFile(path + ss.str(),
         mode,
         block_size,
@@ -168,14 +164,15 @@ int RollableFile::OpenAndMapBlockFile(size_t block_order, bool create_file)
         return MBError::OPEN_FAILURE;
     if (map_file) {
         mem_used += block_size;
-        if (init_jem) {
+        if (configure_jemalloc) {
             if (files[0]->mm_meta == nullptr) {
                 rval = files[0]->InitMemoryManager();
                 if (rval != MBError::SUCCESS) {
                     return rval;
                 }
             }
-            rval = ConfigureJemalloc(files[0]->mm_meta);
+            if (files[0]->mm_meta->arena_index == 0)
+                rval = ConfigureJemalloc(files[0]->mm_meta);
         }
     } else if ((mode & CONSTS::MEMORY_ONLY_MODE) || (mode & CONSTS::OPTION_JEMALLOC)) {
         rval = MBError::MMAP_FAILED;
@@ -440,6 +437,8 @@ int RollableFile::ConfigureJemalloc(MemoryManagerMetadata* mm_meta)
 {
     if (!(mode & CONSTS::OPTION_JEMALLOC))
         return MBError::INVALID_ARG;
+    if (!(mode & CONSTS::ACCESS_MODE_WRITER))
+        return MBError::NOT_ALLOWED;
 
     extent_hooks_t* extent_hooks = mm_meta->extent_hooks;
     extent_hooks->alloc = [](extent_hooks_t* extent_hooks, void* addr, size_t size,
@@ -477,6 +476,7 @@ int RollableFile::ConfigureJemalloc(MemoryManagerMetadata* mm_meta)
     // Store the MemoryManager instance in the global map
     arena_manager_map[arena_ind] = this;
     mm_meta->arena_index = arena_ind;
+    owns_jemalloc_arena = true;
     return MBError::SUCCESS;
 }
 
@@ -486,6 +486,9 @@ int RollableFile::ConfigureJemalloc(MemoryManagerMetadata* mm_meta)
 // This funnction must be called before any other memory allocation
 void* RollableFile::PreAlloc(size_t init_off)
 {
+    if (!(mode & CONSTS::ACCESS_MODE_WRITER))
+        return nullptr;
+
     int rval = CheckAndOpenFile(0, true);
     if (rval != MBError::SUCCESS) {
         throw (int)rval;
@@ -695,6 +698,8 @@ void RollableFile::Purge() const
 // Reset jemalloc
 int RollableFile::ResetJemalloc()
 {
+    if (!owns_jemalloc_arena)
+        return MBError::NOT_ALLOWED;
     return DestroyJemallocArena(true);
 }
 
@@ -723,6 +728,7 @@ int RollableFile::DestroyJemallocArena(bool reinitialize)
         }
         files[0]->mm_meta->arena_index = 0;
     }
+    owns_jemalloc_arena = false;
 
     if (!reinitialize) {
         return MBError::SUCCESS;

--- a/src/rollable_file.h
+++ b/src/rollable_file.h
@@ -110,6 +110,7 @@ private:
     size_t mmap_mem;
     bool sliding_mmap;
     int mode;
+    bool owns_jemalloc_arena;
     size_t sliding_mem_size;
     // shared memory sliding start offset for reader
     // Note writer does not flush sliding mmap during writing.

--- a/src/shm_queue_mgr.cpp
+++ b/src/shm_queue_mgr.cpp
@@ -18,6 +18,7 @@
 
 #include <iostream>
 #include <sys/stat.h>
+#include <time.h>
 
 #include "error.h"
 #include "logger.h"
@@ -26,6 +27,16 @@
 #include "util/shm_mutex.h"
 
 namespace mabain {
+
+uint64_t SHMQ_GetMonotonicTimeMs()
+{
+    struct timespec now;
+    if (clock_gettime(CLOCK_MONOTONIC, &now) != 0)
+        return 0;
+
+    return static_cast<uint64_t>(now.tv_sec) * 1000
+        + static_cast<uint64_t>(now.tv_nsec) / 1000000;
+}
 
 ShmQueueMgr::ShmQueueMgr()
 {
@@ -38,6 +49,9 @@ void ShmQueueMgr::InitShmObjects(shm_lock_and_queue* slaq, int queue_size)
     rval = InitShmMutex(&slaq->lock);
     if (rval != MBError::SUCCESS)
         throw rval;
+
+    for (int i = 0; i < MB_MAX_NUM_SHM_QUEUE_NODE; ++i)
+        slaq->reservation_time_ms[i].store(0, std::memory_order_relaxed);
 
     slaq->initialized = 1;
 }
@@ -59,8 +73,6 @@ shm_lock_and_queue* ShmQueueMgr::CreateFile(uint64_t qid, int qsize,
 
     bool map_qfile = true;
     int q_buff_size = sizeof(shm_lock_and_queue);
-    if (qsize < MB_MAX_NUM_SHM_QUEUE_NODE)
-        q_buff_size -= sizeof(AsyncNode) * (MB_MAX_NUM_SHM_QUEUE_NODE - qsize);
     qfile = ResourcePool::getInstance().OpenFile(qfile_path,
         CONSTS::ACCESS_MODE_WRITER,
         q_buff_size,

--- a/src/shm_queue_mgr.h
+++ b/src/shm_queue_mgr.h
@@ -54,7 +54,10 @@ typedef struct _shm_lock_and_queue {
     int initialized;
     pthread_mutex_t lock;
     AsyncNode queue[MB_MAX_NUM_SHM_QUEUE_NODE];
+    std::atomic<uint64_t> reservation_time_ms[MB_MAX_NUM_SHM_QUEUE_NODE];
 } shm_lock_and_queue;
+
+uint64_t SHMQ_GetMonotonicTimeMs();
 
 class ShmQueueMgr {
 public:

--- a/src/shmq_update.cpp
+++ b/src/shmq_update.cpp
@@ -29,7 +29,10 @@ namespace mabain {
 int Dict::SHMQ_Add(const char* key, int key_len, const char* data, int data_len,
     bool overwrite)
 {
-    if (key_len > MB_ASYNC_SHM_KEY_SIZE || data_len > MB_ASYNC_SHM_DATA_SIZE) {
+    if (key == nullptr || data == nullptr)
+        return MBError::INVALID_ARG;
+    if (key_len <= 0 || key_len > MB_ASYNC_SHM_KEY_SIZE
+        || data_len <= 0 || data_len > MB_ASYNC_SHM_DATA_SIZE) {
         return MBError::OUT_OF_BOUND;
     }
 
@@ -50,7 +53,9 @@ int Dict::SHMQ_Add(const char* key, int key_len, const char* data, int data_len,
 
 int Dict::SHMQ_Remove(const char* key, int len)
 {
-    if (len > MB_ASYNC_SHM_KEY_SIZE)
+    if (key == nullptr)
+        return MBError::INVALID_ARG;
+    if (len <= 0 || len > MB_ASYNC_SHM_KEY_SIZE)
         return MBError::OUT_OF_BOUND;
 
     int err = MBError::SUCCESS;
@@ -114,21 +119,29 @@ int Dict::SHMQ_CollectResource(int64_t m_index_rc_size,
 
 AsyncNode* Dict::SHMQ_AcquireSlot(int& err) const
 {
-    uint32_t index = header->queue_index.fetch_add(1, std::memory_order_release);
-    AsyncNode* node_ptr = queue + (index % header->async_queue_size);
+    uint32_t index = header->queue_index.load(std::memory_order_acquire);
+    for (;;) {
+        uint32_t writer_index = header->writer_index.load(std::memory_order_acquire);
+        if (index - writer_index >= static_cast<uint32_t>(header->async_queue_size)) {
+            err = MBError::TRY_AGAIN;
+            return nullptr;
+        }
 
-    if (node_ptr->in_use.load(std::memory_order_consume)) {
-        // This slot is being processed by writer.
-        err = MBError::TRY_AGAIN;
-        return nullptr;
+        if (header->queue_index.compare_exchange_weak(index, index + 1,
+                std::memory_order_acq_rel, std::memory_order_acquire)) {
+            break;
+        }
     }
 
-    uint16_t nreader = node_ptr->num_reader.fetch_add(1, std::memory_order_release);
-    if (nreader != 0) {
-        // This slot is being processed by another reader.
-        err = MBError::TRY_AGAIN;
-        return nullptr;
-    }
+    uint32_t slot_index = index % header->async_queue_size;
+    AsyncNode* node_ptr = queue + slot_index;
+
+    // queue_index is advanced only when capacity exists. writer_index is
+    // published after the previous occupant has been fully released, so this
+    // producer exclusively owns the corresponding physical slot.
+    node_ptr->num_reader.store(1, std::memory_order_release);
+    slaq->reservation_time_ms[slot_index].store(
+        SHMQ_GetMonotonicTimeMs(), std::memory_order_release);
 
     return node_ptr;
 }
@@ -148,7 +161,9 @@ void Dict::SHMQ_Signal()
 
 bool Dict::SHMQ_Busy() const
 {
-    if ((header->queue_index.load(std::memory_order_consume) != header->writer_index) || header->rc_flag == 1)
+    if ((header->queue_index.load(std::memory_order_acquire)
+            != header->writer_index.load(std::memory_order_acquire))
+        || header->rc_flag == 1)
         return true;
 
     size_t rc_off = header->rc_root_offset.load(std::memory_order_consume);

--- a/src/test/Makefile
+++ b/src/test/Makefile
@@ -9,7 +9,8 @@ TESTSOURCES=$(wildcard *.cpp)
 all: mb_test mb_test1 mb_test2 mb_test_mp multi_writer_bug_test mb_bound_test mb_header_test \
 	mb_mm_test mb_mm_prune_test sigbus_disk_pressure_test errno95_db_writer_test jemalloc_test \
 	shared_prefix_cache_concurrency_test hashmap_lookup_bench jemalloc_restart_rebuild_test \
-	find_lower_bound_concurrency_test
+	find_lower_bound_concurrency_test shmq_reservation_timeout_test \
+	prefix_cache_snapshot_concurrency_test shmq_queue_full_stress_test
 
 mb_mm_prune_test: mb_mm_prune_test.cpp
 	$(CPP) $(CPPFLAGS) mb_mm_prune_test.cpp
@@ -71,6 +72,18 @@ find_lower_bound_concurrency_test: find_lower_bound_concurrency_test.cpp ../../b
 	$(CPP) $(CPPFLAGS) find_lower_bound_concurrency_test.cpp
 	$(CPP) find_lower_bound_concurrency_test.o -o find_lower_bound_concurrency_test $(LDFLAGS)
 
+shmq_reservation_timeout_test: shmq_reservation_timeout_test.cpp ../../build/lib/libmabain.so
+	$(CPP) $(CPPFLAGS) shmq_reservation_timeout_test.cpp
+	$(CPP) shmq_reservation_timeout_test.o -o shmq_reservation_timeout_test $(LDFLAGS)
+
+shmq_queue_full_stress_test: shmq_queue_full_stress_test.cpp ../../build/lib/libmabain.so
+	$(CPP) $(CPPFLAGS) shmq_queue_full_stress_test.cpp
+	$(CPP) shmq_queue_full_stress_test.o -o shmq_queue_full_stress_test $(LDFLAGS)
+
+prefix_cache_snapshot_concurrency_test: prefix_cache_snapshot_concurrency_test.cpp ../../build/lib/libmabain.so
+	$(CPP) $(CPPFLAGS) prefix_cache_snapshot_concurrency_test.cpp
+	$(CPP) prefix_cache_snapshot_concurrency_test.o -o prefix_cache_snapshot_concurrency_test $(LDFLAGS)
+
 
 # Build standalone HashMap lookup benchmark
 hashmap_lookup_bench: hashmap_lookup_bench.cpp ../../build/lib/libmabain.so
@@ -79,4 +92,4 @@ hashmap_lookup_bench: hashmap_lookup_bench.cpp ../../build/lib/libmabain.so
 
 
 clean:
-	-rm -rf *.o mb_test* multi_writer_bug_test mb_bound_test mb_header_test mb_mm_test mb_mm_prune_test sigbus_disk_pressure_test errno95_db_writer_test jemalloc_test jemalloc_restart_rebuild_test shared_prefix_cache_concurrency_test find_lower_bound_concurrency_test hashmap_lookup_bench
+	-rm -rf *.o mb_test* multi_writer_bug_test mb_bound_test mb_header_test mb_mm_test mb_mm_prune_test sigbus_disk_pressure_test errno95_db_writer_test jemalloc_test jemalloc_restart_rebuild_test shared_prefix_cache_concurrency_test find_lower_bound_concurrency_test hashmap_lookup_bench shmq_reservation_timeout_test shmq_queue_full_stress_test prefix_cache_snapshot_concurrency_test

--- a/src/test/TEST_RUNBOOK.md
+++ b/src/test/TEST_RUNBOOK.md
@@ -1,0 +1,351 @@
+# Mabain Test Runbook
+
+This runbook covers every tracked test program and test driver under
+`src/test`, plus the GoogleTest suite under `src/unittest`. Run the tests on a
+Linux validation host from a clean Mabain checkout. Do not run tests that share
+`/var/tmp/mabain_test` concurrently.
+
+## 1. Safety and isolation
+
+- Confirm that no production Mabain process uses `/var/tmp/mabain_test` or any
+  other path selected below. Several tests delete or recreate their database.
+- `shared_prefix_cache_concurrency_test` removes every entry under
+  `/var/tmp/mabain_test` at startup, not only Mabain files.
+- Run `sigbus_disk_pressure_test` only on a disposable host or an isolated
+  `/tmp` filesystem. It intentionally fills `/tmp` to 100%.
+- Run `repro_errno95_real.sh` only on a disposable host with root or passwordless
+  sudo access. It creates filesystems, loop-mounts images, and preserves a 2 GB
+  image and mount by default.
+- The tracked `run_test` script is a historical soak launcher, not a complete or
+  reliable all-tests driver. It omits newer tests, runs for hours, starts the
+  final multi-process workload in the background, and does not wait for it.
+  Use the explicit commands in this runbook instead.
+- Backup validation is intentionally excluded because Mabain backup is not a
+  supported feature. The backup row in `test_list` is already commented out.
+
+## 2. Dependencies and build
+
+Required build dependencies are a C++17 compiler, CMake, GNU Make, jemalloc
+development files, OpenSSL development files, pthreads, GoogleTest, and the
+normal Mabain dependencies. `gcovr` is needed only to generate coverage reports.
+
+From the repository root:
+
+```bash
+cd ~/mabain
+cmake -S . -B build -DMB_WERROR=ON
+cmake --build build --parallel "$(nproc)"
+make -C src/unittest clean build
+make -C src/test clean all
+
+MABAIN_ROOT="$(pwd)"
+export LD_LIBRARY_PATH="$MABAIN_ROOT/build/lib${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
+mkdir -p /var/tmp/mabain_test
+
+reset_mabain_test_db() {
+  find /var/tmp/mabain_test -mindepth 1 -maxdepth 1 \
+    \( -name '_mabain_*' -o -name '_success' -o -name 'mabain.log' \
+       -o -name 'key_id' \) \
+    -delete
+}
+```
+
+The reset helper is used by later sections. Keep the same shell session or
+define it again before running those sections.
+
+The `src/unittest/Makefile` prefixes the test and coverage commands with `-`, so
+`make unit-test` can return success after a failed test. Run the binary directly
+and check its exit status as shown below.
+
+## 3. GoogleTest unit suite
+
+```bash
+cd ~/mabain/src/unittest
+LD_LIBRARY_PATH=../../build/lib ./test_mabain --gtest_brief=1
+```
+
+Pass criteria: exit status 0 and the final summary reports all tests passed.
+
+## 4. Standalone correctness and concurrency tests
+
+Run these sequentially from `src/test`:
+
+```bash
+cd ~/mabain/src/test
+
+./errno95_db_writer_test
+./mb_header_test
+./shmq_reservation_timeout_test
+./shmq_queue_full_stress_test
+./prefix_cache_snapshot_concurrency_test 1000000 4
+./shared_prefix_cache_concurrency_test 200000 4 95
+./find_lower_bound_concurrency_test \
+  /var/tmp/mabain_find_lower_bound_concurrency 24 200000 5000000
+```
+
+Pass criteria:
+
+- Every command exits with status 0.
+- `errno95_db_writer_test` reports successful insert/lookup verification. The
+  separate privileged script in section 8 is what tests a real errno 95
+  filesystem.
+- `shmq_reservation_timeout_test` reports that the stale slot was reclaimed in
+  its expected one-second test window.
+- `shmq_queue_full_stress_test` reports at least one full-queue retry and verifies
+  every queued request.
+- `prefix_cache_snapshot_concurrency_test` reports nonzero hits and no torn or
+  invalid stable snapshot.
+- `shared_prefix_cache_concurrency_test` reports `Post-remove verification OK`
+  and no value mismatch. The fourth argument is best omitted: the current test
+  parses it both as cache capacity and as prefix depth.
+- `find_lower_bound_concurrency_test` reports success for the writer and all
+  reader processes. `TRY_AGAIN` is an accepted transient result.
+
+The direct errno 95 test accepts optional arguments:
+
+```text
+./errno95_db_writer_test [db_dir] [entries] [index_memcap_mb] [data_memcap_mb]
+```
+
+The lower-bound concurrency test accepts:
+
+```text
+./find_lower_bound_concurrency_test [db_dir] [readers] [keys] [writer_operations]
+```
+
+The prefix-cache snapshot test accepts:
+
+```text
+./prefix_cache_snapshot_concurrency_test [writer_iterations] [reader_threads]
+```
+
+## 5. Jemalloc restart and rebuild tests
+
+The first eight modes are independent. Give each one a unique directory:
+
+```bash
+cd ~/mabain/src/test
+
+for mode in \
+  header_metadata arena_cursor startup_gate async_reject \
+  shrink_only evacuate_only recover_shrink recover_evacuate
+do
+  MABAIN_JEMALLOC_REBUILD_DIR="/var/tmp/mabain_test/jemalloc_$mode" \
+    ./jemalloc_restart_rebuild_test "$mode" || exit 1
+done
+```
+
+The remaining five modes form one ordered multi-process scenario:
+
+```text
+full_cycle_prepare -> reader_loop -> full_cycle ->
+full_cycle_insert_verify -> full_cycle_verify_reuse
+```
+
+`run_jemalloc_rebuild_pressure.sh` is intended to orchestrate that scenario,
+but the current script exports `MABAIN_READER_CONNECT_ID` while the test binary
+reads `MABAIN_CONNECT_ID`. Until those names are made consistent, use this
+manual form so every reader receives a distinct connection ID:
+
+```bash
+cd ~/mabain/src/test
+
+MABAIN_JEMALLOC_REBUILD_DIR="$(mktemp -d /var/tmp/mabain_test/jemalloc_cycle.XXXXXX)"
+export MABAIN_JEMALLOC_REBUILD_DIR
+
+./jemalloc_restart_rebuild_test full_cycle_prepare
+
+MABAIN_CONNECT_ID=28673 ./jemalloc_restart_rebuild_test reader_loop & reader1=$!
+MABAIN_CONNECT_ID=28674 ./jemalloc_restart_rebuild_test reader_loop & reader2=$!
+MABAIN_CONNECT_ID=28675 ./jemalloc_restart_rebuild_test reader_loop & reader3=$!
+MABAIN_CONNECT_ID=28676 ./jemalloc_restart_rebuild_test reader_loop & reader4=$!
+
+sleep 1
+./jemalloc_restart_rebuild_test full_cycle
+sleep 2
+touch "$MABAIN_JEMALLOC_REBUILD_DIR/full_cycle.stop"
+
+wait "$reader1" || exit 1
+wait "$reader2" || exit 1
+wait "$reader3" || exit 1
+wait "$reader4" || exit 1
+
+./jemalloc_restart_rebuild_test full_cycle_insert_verify
+./jemalloc_restart_rebuild_test full_cycle_verify_reuse
+```
+
+Pass criteria: every mode exits with status 0, the writer and verification modes
+print `passed`, and all four reader processes exit successfully.
+
+## 6. Memory-management, lower-bound, and writer stress tests
+
+These tests use the shared `/var/tmp/mabain_test` path and may be CPU-, memory-,
+or time-intensive. Start with a clean dedicated directory and run sequentially.
+
+```bash
+cd ~/mabain/src/test
+
+reset_mabain_test_db
+./mb_mm_test -iter 50 -k int -n 500000
+./mb_mm_test -iter 50 -k sha1 -n 500000
+
+reset_mabain_test_db
+./mb_mm_prune_test -iter 50 -k int -n 500000
+./mb_mm_prune_test -iter 50 -k sha2 -n 500000
+
+reset_mabain_test_db
+./multi_writer_bug_test
+
+reset_mabain_test_db
+./mb_bound_test
+```
+
+Purpose and pass criteria:
+
+- `mb_mm_test` repeatedly adds/removes random keys under jemalloc and asserts
+  that pending data and index buffers return to zero.
+- `mb_mm_prune_test` exercises offset-linked pruning and purge under jemalloc.
+- `multi_writer_bug_test` starts 32 producer/reader threads against one async
+  writer, then verifies overwrite behavior. It performs a large number of
+  operations even though it has no arguments.
+- `mb_bound_test` validates and benchmarks `FindLowerBound` against `std::map`
+  for text integers, 4-byte binary integers, SHA-1 keys, and SHA-256 keys. It
+  inserts one million candidates for each key type.
+
+All four programs use assertions for correctness; an abort or nonzero exit is a
+failure.
+
+## 7. Legacy data-driven and soak tests
+
+These are part of the tracked test inventory but are not short pre-commit tests.
+They require the large `key_list_*` input files present in `src/test`. Only
+`key_list_3` is tracked by Git, so verify the local fixture set first:
+
+```bash
+cd ~/mabain/src/test
+ls -lh key_list_1 key_list_2 key_list_3 key_list_4 key_list_5 key_list_6
+```
+
+Run the jemalloc data-driven suite:
+
+```bash
+reset_mabain_test_db
+./jemalloc_test /var/tmp/mabain_test/ ./jemalloc_test_list
+```
+
+Run the general data-driven suite. `test_list` includes very large memory caps
+and workloads, so use a host with sufficient RAM, disk, and run time:
+
+```bash
+reset_mabain_test_db
+./mb_test /var/tmp/mabain_test/ ./test_list
+```
+
+Both programs create `/var/tmp/mabain_test/_success` only after their complete
+input list finishes. A nonzero exit, assertion, or missing success marker is a
+failure.
+
+Run the two fixed-duration resource-collection soaks with an explicitly chosen
+duration in seconds. The historical durations are 1800 and 3600 seconds:
+
+```bash
+reset_mabain_test_db
+./mb_test1 /var/tmp/mabain_test 1800
+
+reset_mabain_test_db
+./mb_test2 /var/tmp/mabain_test 3600
+```
+
+`mb_test1` persists its key range in `/var/tmp/mabain_test/key_id`; the reset
+helper removes it for a fresh run. Each soak creates `_success` only after
+normal completion.
+
+Run the historical multi-process writer/producer scenario as one coordinated
+group and wait for every process:
+
+```bash
+reset_mabain_test_db
+./mb_test_mp -d /var/tmp/mabain_test -w -t 860 & master_writer=$!
+sleep 1
+./mb_test_mp -d /var/tmp/mabain_test -n 1800000 & producer1=$!
+./mb_test_mp -d /var/tmp/mabain_test -n 1800000 -k sha1 & producer2=$!
+./mb_test_mp -d /var/tmp/mabain_test -n 18000000 -k sha2 & producer3=$!
+
+wait "$producer1" || exit 1
+wait "$producer2" || exit 1
+wait "$producer3" || exit 1
+wait "$master_writer" || exit 1
+```
+
+`mb_test_mp` options are `-d <db_dir>`, `-w` for the master async writer,
+`-n <count>`, `-n0 <starting_id>`, `-t <seconds>`, and
+`-k <int|sha1|sha2>`.
+
+## 8. Privileged and destructive filesystem tests
+
+### Real errno 95 reproduction
+
+Run only on a disposable Linux host. The default test probes vfat, msdos,
+minix, bfs, and ntfs loop-mounted filesystems, inserts one million records, and
+keeps its final image and mount for inspection:
+
+```bash
+cd ~/mabain
+KEEP_ARTIFACTS=0 src/test/repro_errno95_real.sh
+```
+
+Useful overrides are `FS_CANDIDATES`, `INSERT_LOOKUP_COUNT`,
+`MEMCAP_INDEX_MB`, `MEMCAP_DATA_MB`, `IMAGE_SIZE_MB`, and `KEEP_ARTIFACTS`.
+Pass criteria: the script reports a real kernel `EOPNOTSUPP`/errno 95 path and
+the writer completes insert/lookup validation.
+
+### SIGBUS disk-pressure test
+
+Do not run this on a shared host. Its child process consumes all available
+space on the filesystem backing `/tmp` and then the parent performs 100,000
+database insertions:
+
+```bash
+cd ~/mabain/src/test
+./sigbus_disk_pressure_test
+```
+
+Pass criteria for the hardened allocation path: exit status 0 and no SIGBUS.
+The program exits 1 if it reproduces SIGBUS, even though its diagnostic text
+calls that a successful reproduction.
+
+## 9. Performance-only benchmark
+
+`hashmap_lookup_bench` measures the internal HashMap and is not a correctness
+gate beyond successful insertion and lookup hits:
+
+```bash
+cd ~/mabain/src/test
+./hashmap_lookup_bench \
+  1000000 5000000 /var/tmp/mabain_hashmap_bench 256 0.5 1
+```
+
+Arguments are:
+
+```text
+<entries> [lookups] [backing_path] [memory_mb] [load_factor] [compact64]
+```
+
+Record the hit percentage and average nanoseconds per lookup. Compare
+performance only on an otherwise idle host using the same binary, fixture,
+CPU affinity, and run count.
+
+## 10. Final validation record
+
+For a commit or pull request, record:
+
+```bash
+cd ~/mabain
+git rev-parse HEAD
+git status --short
+git diff --check
+```
+
+Also record the build commands, each test command and exit status, the GoogleTest
+pass count, any intentionally skipped privileged/destructive test, and the
+reason for the skip. Do not treat benchmark throughput as a correctness result.

--- a/src/test/TEST_RUNBOOK.md
+++ b/src/test/TEST_RUNBOOK.md
@@ -13,9 +13,11 @@ Linux validation host from a clean Mabain checkout. Do not run tests that share
   `/var/tmp/mabain_test` at startup, not only Mabain files.
 - Run `sigbus_disk_pressure_test` only on a disposable host or an isolated
   `/tmp` filesystem. It intentionally fills `/tmp` to 100%.
-- Run `repro_errno95_real.sh` only on a disposable host with root or passwordless
-  sudo access. It creates filesystems, loop-mounts images, and preserves a 2 GB
-  image and mount by default.
+- Run `repro_errno95_real.sh` only on a Linux validation host with root or
+  passwordless sudo access and enough free space under `/tmp`. It creates a 2 GB
+  filesystem image and loop-mounts it. Use `KEEP_ARTIFACTS=0` for normal
+  validation so the mount, loop device, image, and probe error file are cleaned
+  up on exit; the script default is to preserve them for debugging.
 - The tracked `run_test` script is a historical soak launcher, not a complete or
   reliable all-tests driver. It omits newer tests, runs for hours, starts the
   final multi-process workload in the background, and does not wait for it.
@@ -285,9 +287,17 @@ wait "$master_writer" || exit 1
 
 ### Real errno 95 reproduction
 
-Run only on a disposable Linux host. The default test probes vfat, msdos,
-minix, bfs, and ntfs loop-mounted filesystems, inserts one million records, and
-keeps its final image and mount for inspection:
+Run only on a Linux validation host with root or passwordless sudo access. The
+default test probes vfat, msdos, minix, bfs, and ntfs. For each available
+filesystem it creates a 2 GB image under `/tmp`, formats and loop-mounts it, and
+uses a 1 MB `fallocate` probe. Minix is formatted as Minix v3. The first mounted
+filesystem whose probe returns real kernel `EOPNOTSUPP`/errno 95 is used for the
+Mabain test. Which candidate is selected can vary with the host kernel and
+filesystem tools; on the current validation host, vfat and msdos supported the
+probe and Minix produced errno 95.
+
+The recommended invocation automatically cleans up the mount, loop device,
+image, and probe error file even after a normal test failure:
 
 ```bash
 cd ~/mabain
@@ -296,8 +306,29 @@ KEEP_ARTIFACTS=0 src/test/repro_errno95_real.sh
 
 Useful overrides are `FS_CANDIDATES`, `INSERT_LOOKUP_COUNT`,
 `MEMCAP_INDEX_MB`, `MEMCAP_DATA_MB`, `IMAGE_SIZE_MB`, and `KEEP_ARTIFACTS`.
-Pass criteria: the script reports a real kernel `EOPNOTSUPP`/errno 95 path and
-the writer completes insert/lookup validation.
+
+Pass criteria:
+
+- The probe selects a filesystem after receiving real kernel errno 95.
+- The Mabain log reports `errno=95, falling back to ftruncate` for its files.
+- `errno95_db_writer_test` completes all configured inserts and verifies every
+  lookup; the default is one million of each.
+- The script exits with status 0 and reports `SUCCESS: real filesystem
+  reproduction of errno=95 confirmed`.
+
+A pass means errno 95 was reproduced and Mabain handled it correctly. It does
+not mean the filesystem stopped returning errno 95. With `KEEP_ARTIFACTS=0`,
+the script retains only its small Mabain log copy under
+`/tmp/mabain_errno95_log_<fs>_<pid>.txt`.
+
+After an interrupted run, verify that no test mount or loop device remains:
+
+```bash
+findmnt -rn -o SOURCE,TARGET,FSTYPE | grep mabain_errno95 || true
+sudo losetup -a | grep mabain_errno95 || true
+find /tmp -maxdepth 1 \
+  \( -name 'mabain_errno95_*.img' -o -name 'mabain_errno95_mnt_*' \) -print
+```
 
 ### SIGBUS disk-pressure test
 

--- a/src/test/prefix_cache_snapshot_concurrency_test.cpp
+++ b/src/test/prefix_cache_snapshot_concurrency_test.cpp
@@ -1,0 +1,136 @@
+/**
+ * Stress the prefix-cache optimistic snapshot protocol on one hot slot.
+ */
+
+#include <atomic>
+#include <cstdint>
+#include <cstdlib>
+#include <cstring>
+#include <filesystem>
+#include <iostream>
+#include <thread>
+#include <vector>
+
+#include "db.h"
+#include "dict.h"
+#include "mabain_consts.h"
+#include "util/prefix_cache.h"
+
+using namespace mabain;
+
+namespace {
+
+bool SameBody(const PrefixCacheEntry& lhs, const PrefixCacheEntry& rhs)
+{
+    return lhs.edge_offset == rhs.edge_offset
+        && memcmp(lhs.edge_buff, rhs.edge_buff, sizeof(lhs.edge_buff)) == 0
+        && lhs.edge_skip == rhs.edge_skip;
+}
+
+PrefixCacheEntry MakeEntry(uint8_t value, uint32_t origin)
+{
+    PrefixCacheEntry entry {};
+    entry.edge_offset = value == 0x11 ? 0x1111111111111111ULL
+                                      : 0x2222222222222222ULL;
+    memset(entry.edge_buff, value, sizeof(entry.edge_buff));
+    entry.edge_skip = value;
+    entry.lf_counter = origin;
+    return entry;
+}
+
+} // namespace
+
+int main(int argc, char** argv)
+{
+    const uint64_t iterations = argc > 1
+        ? static_cast<uint64_t>(std::strtoull(argv[1], nullptr, 10))
+        : 500000;
+    const unsigned reader_count = argc > 2
+        ? static_cast<unsigned>(std::strtoul(argv[2], nullptr, 10))
+        : 4;
+    const std::string db_dir = "/var/tmp/mabain_prefix_cache_snapshot_test";
+
+    std::error_code ec;
+    std::filesystem::remove_all(db_dir, ec);
+    std::filesystem::create_directories(db_dir, ec);
+    if (ec) {
+        std::cerr << "failed to prepare test directory: " << ec.message() << '\n';
+        return 1;
+    }
+
+    DB writer(db_dir.c_str(),
+        CONSTS::WriterOptions() | CONSTS::OPTION_PREFIX_CACHE);
+    if (!writer.is_open()) {
+        std::cerr << "writer open failed: " << writer.StatusStr() << '\n';
+        return 1;
+    }
+
+    PrefixCache* cache = writer.GetDictPtr()->ActivePrefixCache();
+    if (cache == nullptr) {
+        std::cerr << "prefix cache is not active\n";
+        return 1;
+    }
+
+    const uint8_t key[] = { 'p', 'c' };
+    const PrefixCacheEntry entry_a = MakeEntry(0x11, 1);
+    const PrefixCacheEntry entry_b = MakeEntry(0x22, 2);
+    cache->PutAtDepth(key, 2, entry_a);
+
+    std::atomic<bool> start { false };
+    std::atomic<bool> stop { false };
+    std::atomic<bool> failed { false };
+    std::atomic<uint64_t> hits { 0 };
+    std::atomic<uint64_t> misses { 0 };
+    std::atomic<uint64_t> retries { 0 };
+
+    std::vector<std::thread> readers;
+    readers.reserve(reader_count);
+    for (unsigned i = 0; i < reader_count; ++i) {
+        readers.emplace_back([&] {
+            while (!start.load(std::memory_order_acquire))
+                std::this_thread::yield();
+
+            while (!stop.load(std::memory_order_acquire)) {
+                PrefixCacheEntry out {};
+                int depth = cache->GetDepth(key, 2, out);
+                if (depth == PrefixCache::UNSTABLE) {
+                    retries.fetch_add(1, std::memory_order_relaxed);
+                    continue;
+                }
+                if (depth == 0) {
+                    misses.fetch_add(1, std::memory_order_relaxed);
+                    continue;
+                }
+                if (depth != 2 || (!SameBody(out, entry_a) && !SameBody(out, entry_b))) {
+                    failed.store(true, std::memory_order_release);
+                    stop.store(true, std::memory_order_release);
+                    break;
+                }
+                hits.fetch_add(1, std::memory_order_relaxed);
+            }
+        });
+    }
+
+    start.store(true, std::memory_order_release);
+    for (uint64_t i = 0; i < iterations && !failed.load(std::memory_order_acquire); ++i)
+        cache->PutAtDepth(key, 2, (i & 1) ? entry_a : entry_b);
+    stop.store(true, std::memory_order_release);
+
+    for (std::thread& reader : readers)
+        reader.join();
+
+    PrefixCacheEntry final_entry {};
+    int final_depth = cache->GetDepth(key, 2, final_entry);
+    bool final_valid = final_depth == 2
+        && (SameBody(final_entry, entry_a) || SameBody(final_entry, entry_b));
+
+    std::cout << "prefix cache snapshot concurrency: hits=" << hits.load()
+              << " misses=" << misses.load()
+              << " retries=" << retries.load() << '\n';
+
+    if (failed.load() || !final_valid || hits.load() == 0) {
+        std::cerr << "prefix cache returned a torn or invalid stable snapshot\n";
+        return 2;
+    }
+    return 0;
+}

--- a/src/test/shared_prefix_cache_concurrency_test.cpp
+++ b/src/test/shared_prefix_cache_concurrency_test.cpp
@@ -98,7 +98,8 @@ static std::vector<std::string> generate_keys(int n)
 
 static void reader_thread_fn(const TestConfig& cfg, const std::vector<std::string>& keys, Metrics& m, const std::atomic<int>* last_added)
 {
-    DB rdb(cfg.dbdir.c_str(), CONSTS::ReaderOptions());
+    DB rdb(cfg.dbdir.c_str(),
+        CONSTS::ReaderOptions() | CONSTS::OPTION_PREFIX_CACHE);
     if (!rdb.is_open()) {
         std::cerr << "reader open failed" << std::endl;
         return;

--- a/src/test/shared_prefix_cache_concurrency_test.cpp
+++ b/src/test/shared_prefix_cache_concurrency_test.cpp
@@ -76,7 +76,8 @@ static void ensure_clean_db(const std::string& dbdir)
 
 static bool initialize_db_header(const TestConfig& cfg)
 {
-    DB writer(cfg.dbdir.c_str(), CONSTS::WriterOptions());
+    DB writer(cfg.dbdir.c_str(),
+        CONSTS::WriterOptions() | CONSTS::OPTION_PREFIX_CACHE);
     if (!writer.is_open()) {
         std::cerr << "writer init open failed: " << writer.StatusStr() << std::endl;
         return false;
@@ -166,7 +167,8 @@ static void stop_readers(Metrics& m, std::vector<std::thread>& readers)
 
 static bool run_interleaved_workload(const TestConfig& cfg, const std::vector<std::string>& keys, double& work_sec, std::atomic<int>& last_added)
 {
-    DB writer(cfg.dbdir.c_str(), CONSTS::WriterOptions());
+    DB writer(cfg.dbdir.c_str(),
+        CONSTS::WriterOptions() | CONSTS::OPTION_PREFIX_CACHE);
     if (!writer.is_open()) {
         std::cerr << "writer open failed: " << writer.StatusStr() << std::endl;
         return false;

--- a/src/test/shmq_queue_full_stress_test.cpp
+++ b/src/test/shmq_queue_full_stress_test.cpp
@@ -1,0 +1,410 @@
+/**
+ * Copyright (C) 2026 Cisco Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2.
+ */
+
+#include <atomic>
+#include <cerrno>
+#include <chrono>
+#include <csignal>
+#include <filesystem>
+#include <iostream>
+#include <poll.h>
+#include <string>
+#include <system_error>
+#include <sys/wait.h>
+#include <thread>
+#include <unistd.h>
+#include <vector>
+
+#include "../db.h"
+#include "../error.h"
+#include "../resource_pool.h"
+
+using namespace mabain;
+
+namespace {
+
+constexpr uint32_t kQueueSize = 2;
+constexpr int kProducerCount = 16;
+constexpr int kRequestsPerProducer = 500;
+
+bool ReadByte(int fd, char& value, int timeout_ms)
+{
+    struct pollfd pfd = { fd, POLLIN, 0 };
+    int rval;
+    do {
+        rval = poll(&pfd, 1, timeout_ms);
+    } while (rval < 0 && errno == EINTR);
+
+    if (rval != 1 || !(pfd.revents & POLLIN))
+        return false;
+
+    ssize_t nread;
+    do {
+        nread = read(fd, &value, sizeof(value));
+    } while (nread < 0 && errno == EINTR);
+    return nread == static_cast<ssize_t>(sizeof(value));
+}
+
+bool WriteByte(int fd, char value)
+{
+    ssize_t nwritten;
+    do {
+        nwritten = write(fd, &value, sizeof(value));
+    } while (nwritten < 0 && errno == EINTR);
+    return nwritten == static_cast<ssize_t>(sizeof(value));
+}
+
+bool WaitForChild(pid_t pid, int& status, std::chrono::seconds timeout)
+{
+    auto deadline = std::chrono::steady_clock::now() + timeout;
+    while (std::chrono::steady_clock::now() < deadline) {
+        pid_t rval = waitpid(pid, &status, WNOHANG);
+        if (rval == pid)
+            return true;
+        if (rval < 0 && errno != EINTR)
+            return false;
+        std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    }
+    return false;
+}
+
+class WriterChild {
+public:
+    WriterChild(pid_t child_pid, int control_fd)
+        : pid(child_pid)
+        , fd(control_fd)
+        , stopped(false)
+    {
+    }
+
+    ~WriterChild()
+    {
+        if (pid <= 0)
+            return;
+        if (stopped)
+            kill(pid, SIGCONT);
+        kill(pid, SIGTERM);
+        int status = 0;
+        waitpid(pid, &status, 0);
+        if (fd >= 0)
+            close(fd);
+    }
+
+    bool Pause()
+    {
+        if (kill(pid, SIGSTOP) != 0)
+            return false;
+        int status = 0;
+        pid_t rval;
+        do {
+            rval = waitpid(pid, &status, WUNTRACED);
+        } while (rval < 0 && errno == EINTR);
+        if (rval != pid || !WIFSTOPPED(status))
+            return false;
+        stopped = true;
+        return true;
+    }
+
+    bool Resume()
+    {
+        if (!stopped)
+            return true;
+        if (kill(pid, SIGCONT) != 0)
+            return false;
+        stopped = false;
+        return true;
+    }
+
+    bool Shutdown()
+    {
+        if (!Resume() || !WriteByte(fd, 'q'))
+            return false;
+        close(fd);
+        fd = -1;
+
+        int status = 0;
+        if (!WaitForChild(pid, status, std::chrono::seconds(10)))
+            return false;
+        pid = -1;
+        return WIFEXITED(status) && WEXITSTATUS(status) == 0;
+    }
+
+private:
+    pid_t pid;
+    int fd;
+    bool stopped;
+};
+
+int RunWriter(const std::string& db_path, const std::string& queue_dir,
+    int ready_fd, int control_fd)
+{
+    MBConfig config = { 0 };
+    config.mbdir = db_path.c_str();
+    config.options = CONSTS::WriterOptions() | CONSTS::ASYNC_WRITER_MODE;
+    config.memcap_index = 64 * 1024 * 1024LL;
+    config.memcap_data = 64 * 1024 * 1024LL;
+    config.queue_size = kQueueSize;
+    config.queue_dir = queue_dir.c_str();
+    config.async_queue_reservation_timeout_sec = 10;
+
+    DB db(config);
+    if (!WriteByte(ready_fd, db.is_open() ? '1' : '0'))
+        return 2;
+    close(ready_fd);
+    if (!db.is_open())
+        return 3;
+
+    char command = 0;
+    if (!ReadByte(control_fd, command, -1) || command != 'q')
+        return 4;
+    close(control_fd);
+    return db.Close() == MBError::SUCCESS ? 0 : 5;
+}
+
+int QueueWithRetry(DB& db, const std::string& key, const std::string& value,
+    std::chrono::steady_clock::time_point deadline, std::atomic<uint64_t>* retries)
+{
+    for (;;) {
+        int rval = db.Add(key, value, true);
+        if (rval != MBError::TRY_AGAIN)
+            return rval;
+        if (std::chrono::steady_clock::now() >= deadline)
+            return rval;
+        if (retries != nullptr)
+            retries->fetch_add(1, std::memory_order_relaxed);
+        std::this_thread::yield();
+    }
+}
+
+bool WaitForValue(DB& db, const std::string& key, const std::string& expected,
+    std::chrono::seconds timeout)
+{
+    auto deadline = std::chrono::steady_clock::now() + timeout;
+    while (std::chrono::steady_clock::now() < deadline) {
+        MBData data;
+        int rval = db.Find(key, data);
+        if (rval == MBError::SUCCESS) {
+            return std::string(reinterpret_cast<const char*>(data.buff), data.data_len)
+                == expected;
+        }
+        if (rval != MBError::NOT_EXIST && rval != MBError::TRY_AGAIN)
+            return false;
+        std::this_thread::sleep_for(std::chrono::milliseconds(2));
+    }
+    return false;
+}
+
+bool WaitUntilIdle(DB& db, std::chrono::seconds timeout)
+{
+    auto deadline = std::chrono::steady_clock::now() + timeout;
+    while (std::chrono::steady_clock::now() < deadline) {
+        if (!db.AsyncWriterBusy())
+            return true;
+        std::this_thread::sleep_for(std::chrono::milliseconds(2));
+    }
+    return false;
+}
+
+std::string StressKey(int producer, int request)
+{
+    return "shmq-stress-" + std::to_string(producer) + "-" + std::to_string(request);
+}
+
+} // namespace
+
+int main()
+{
+    signal(SIGPIPE, SIG_IGN);
+
+    std::string db_dir = "/var/tmp/mabain_shmq_full_stress_" + std::to_string(getpid());
+    std::string db_path = db_dir + "/";
+    std::error_code ec;
+    std::filesystem::remove_all(db_dir, ec);
+    ec.clear();
+    if (!std::filesystem::create_directories(db_dir, ec) || ec) {
+        std::cerr << "failed to create test directory: " << ec.message() << std::endl;
+        return 1;
+    }
+
+    int ready_pipe[2];
+    int control_pipe[2];
+    if (pipe(ready_pipe) != 0 || pipe(control_pipe) != 0) {
+        std::cerr << "failed to create control pipes" << std::endl;
+        return 2;
+    }
+
+    pid_t writer_pid = fork();
+    if (writer_pid < 0) {
+        std::cerr << "failed to fork writer" << std::endl;
+        return 3;
+    }
+    if (writer_pid == 0) {
+        close(ready_pipe[0]);
+        close(control_pipe[1]);
+        int rval = RunWriter(db_path, db_dir, ready_pipe[1], control_pipe[0]);
+        _exit(rval);
+    }
+
+    close(ready_pipe[1]);
+    close(control_pipe[0]);
+    WriterChild writer(writer_pid, control_pipe[1]);
+
+    char ready = 0;
+    if (!ReadByte(ready_pipe[0], ready, 10000) || ready != '1') {
+        std::cerr << "writer failed to initialize" << std::endl;
+        return 4;
+    }
+    close(ready_pipe[0]);
+
+    MBConfig producer_config = { 0 };
+    producer_config.mbdir = db_path.c_str();
+    producer_config.options = CONSTS::ReaderOptions();
+    producer_config.memcap_index = 64 * 1024 * 1024LL;
+    producer_config.memcap_data = 64 * 1024 * 1024LL;
+    producer_config.queue_size = kQueueSize;
+    producer_config.queue_dir = db_dir.c_str();
+    DB monitor_db(producer_config);
+    if (!monitor_db.is_open()) {
+        std::cerr << "producer failed to open database: " << monitor_db.StatusStr() << std::endl;
+        return 5;
+    }
+
+    // Stop the writer so the two-slot queue can be filled deterministically.
+    if (!writer.Pause()) {
+        std::cerr << "failed to pause writer" << std::endl;
+        return 6;
+    }
+
+    const std::string prefill_value = "prefill-value";
+    for (uint32_t i = 0; i < kQueueSize; ++i) {
+        std::string key = "shmq-prefill-" + std::to_string(i);
+        int rval = monitor_db.Add(key, prefill_value, true);
+        if (rval != MBError::SUCCESS) {
+            std::cerr << "failed to fill queue at slot " << i << std::endl;
+            return 7;
+        }
+    }
+
+    const std::string rejected_key = "shmq-must-retry";
+    if (monitor_db.Add(rejected_key, prefill_value, true) != MBError::TRY_AGAIN) {
+        std::cerr << "full queue did not reject acquisition" << std::endl;
+        return 8;
+    }
+
+    if (!writer.Resume()) {
+        std::cerr << "failed to resume writer" << std::endl;
+        return 9;
+    }
+    for (uint32_t i = 0; i < kQueueSize; ++i) {
+        std::string key = "shmq-prefill-" + std::to_string(i);
+        if (!WaitForValue(monitor_db, key, prefill_value, std::chrono::seconds(5))) {
+            std::cerr << "writer failed to process prefilled request " << i << std::endl;
+            return 10;
+        }
+    }
+
+    // A successful request queued after the rejected acquisition must not sit
+    // behind a logical hole for the writer's ten-second reservation timeout.
+    const std::string sentinel_key = "shmq-after-rejection";
+    auto sentinel_deadline = std::chrono::steady_clock::now() + std::chrono::seconds(5);
+    if (QueueWithRetry(monitor_db, sentinel_key, prefill_value,
+            sentinel_deadline, nullptr)
+        != MBError::SUCCESS) {
+        std::cerr << "failed to queue sentinel request" << std::endl;
+        return 11;
+    }
+    if (!WaitForValue(monitor_db, sentinel_key, prefill_value,
+            std::chrono::seconds(5))) {
+        std::cerr << "sentinel request was blocked behind a queue hole" << std::endl;
+        return 12;
+    }
+
+    std::atomic<bool> start(false);
+    std::atomic<int> ready_count(0);
+    std::atomic<int> failures(0);
+    std::atomic<uint64_t> retries(0);
+
+    std::vector<std::thread> producers;
+    producers.reserve(kProducerCount);
+    for (int producer = 0; producer < kProducerCount; ++producer) {
+        producers.emplace_back([&, producer]() {
+            MBConfig config = producer_config;
+            DB db(config);
+            bool open = db.is_open();
+            ready_count.fetch_add(1, std::memory_order_release);
+            while (!start.load(std::memory_order_acquire))
+                std::this_thread::yield();
+            if (!open) {
+                failures.fetch_add(1, std::memory_order_relaxed);
+                return;
+            }
+
+            auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(60);
+            const std::string value(512, static_cast<char>('a' + producer % 26));
+            for (int request = 0; request < kRequestsPerProducer; ++request) {
+                std::string key = StressKey(producer, request);
+                if (QueueWithRetry(db, key, value, deadline, &retries)
+                    != MBError::SUCCESS) {
+                    failures.fetch_add(1, std::memory_order_relaxed);
+                    return;
+                }
+            }
+        });
+    }
+
+    while (ready_count.load(std::memory_order_acquire) != kProducerCount)
+        std::this_thread::yield();
+    start.store(true, std::memory_order_release);
+
+    for (std::thread& producer : producers)
+        producer.join();
+
+    if (failures.load(std::memory_order_acquire) != 0) {
+        std::cerr << "producer stress failed" << std::endl;
+        return 13;
+    }
+    if (retries.load(std::memory_order_acquire) == 0) {
+        std::cerr << "stress did not create queue contention" << std::endl;
+        return 14;
+    }
+    if (!WaitUntilIdle(monitor_db, std::chrono::seconds(30))) {
+        std::cerr << "writer failed to drain stress requests" << std::endl;
+        return 15;
+    }
+
+    for (int producer = 0; producer < kProducerCount; ++producer) {
+        const std::string expected(512, static_cast<char>('a' + producer % 26));
+        for (int request = 0; request < kRequestsPerProducer; ++request) {
+            std::string key = StressKey(producer, request);
+            MBData data;
+            int rval = monitor_db.Find(key, data);
+            if (rval != MBError::SUCCESS
+                || std::string(reinterpret_cast<const char*>(data.buff), data.data_len)
+                    != expected) {
+                std::cerr << "missing or corrupt stress request: " << key << std::endl;
+                return 16;
+            }
+        }
+    }
+
+    monitor_db.Close();
+    ResourcePool::getInstance().RemoveAll();
+    if (!writer.Shutdown()) {
+        std::cerr << "writer failed to shut down cleanly" << std::endl;
+        return 17;
+    }
+
+    std::filesystem::remove_all(db_dir, ec);
+    if (ec) {
+        std::cerr << "test passed, but cleanup failed: " << ec.message() << std::endl;
+        return 18;
+    }
+
+    std::cout << "shmq_queue_full_stress_test passed with "
+              << retries.load(std::memory_order_relaxed) << " full-queue retries" << std::endl;
+    return 0;
+}

--- a/src/test/shmq_reservation_timeout_test.cpp
+++ b/src/test/shmq_reservation_timeout_test.cpp
@@ -1,0 +1,143 @@
+/**
+ * Copyright (C) 2026 Cisco Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2.
+ */
+
+#include <algorithm>
+#include <chrono>
+#include <filesystem>
+#include <iostream>
+#include <memory>
+#include <string>
+#include <system_error>
+#include <thread>
+#include <unistd.h>
+
+#include "../db.h"
+#include "../dict.h"
+#include "../resource_pool.h"
+#include "../shm_queue_mgr.h"
+
+using namespace mabain;
+
+namespace {
+
+constexpr uint32_t kTimeoutSec = 1;
+
+int Fail(std::unique_ptr<DB>& db, const std::string& db_dir,
+    const std::string& message, int code)
+{
+    std::cerr << message << std::endl;
+    db.reset();
+    ResourcePool::getInstance().RemoveAll();
+    std::error_code ec;
+    std::filesystem::remove_all(db_dir, ec);
+    return code;
+}
+
+} // namespace
+
+int main()
+{
+    std::string db_dir = "/var/tmp/mabain_shmq_timeout_test_" + std::to_string(getpid());
+    std::string db_path = db_dir + "/";
+    std::error_code ec;
+    std::filesystem::remove_all(db_dir, ec);
+    ec.clear();
+    if (!std::filesystem::create_directories(db_dir, ec) || ec) {
+        std::cerr << "failed to create test directory: " << ec.message() << std::endl;
+        return 1;
+    }
+
+    MBConfig config = { 0 };
+    config.mbdir = db_path.c_str();
+    config.options = CONSTS::WriterOptions() | CONSTS::ASYNC_WRITER_MODE;
+    config.memcap_index = 64 * 1024 * 1024LL;
+    config.memcap_data = 64 * 1024 * 1024LL;
+    config.queue_size = 4;
+    config.queue_dir = db_dir.c_str();
+    config.async_queue_reservation_timeout_sec = kTimeoutSec;
+
+    std::unique_ptr<DB> db(new DB(config));
+    if (!db->is_open())
+        return Fail(db, db_dir, std::string("DB open failed: ") + db->StatusStr(), 2);
+
+    Dict* dict = db->GetDictPtr();
+    IndexHeader* header = dict == nullptr ? nullptr : dict->GetHeaderPtr();
+    AsyncNode* queue = dict == nullptr ? nullptr : dict->GetAsyncQueuePtr();
+    std::atomic<uint64_t>* reservation_time_ms = dict == nullptr
+        ? nullptr
+        : dict->GetAsyncQueueReservationTimePtr();
+    if (header == nullptr || queue == nullptr || reservation_time_ms == nullptr)
+        return Fail(db, db_dir, "async queue was not initialized", 3);
+
+    std::this_thread::sleep_for(std::chrono::milliseconds(50));
+
+    uint32_t base = header->queue_index.load(std::memory_order_acquire);
+    uint32_t first_index = base % header->async_queue_size;
+    uint32_t second_index = (base + 1) % header->async_queue_size;
+    AsyncNode& first = queue[first_index];
+    AsyncNode& second = queue[second_index];
+
+    first.num_reader.store(1, std::memory_order_release);
+    reservation_time_ms[first_index].store(
+        SHMQ_GetMonotonicTimeMs(), std::memory_order_release);
+
+    const std::string key = "shmq-timeout-key";
+    const std::string value = "published-after-stale-reservation";
+    if (key.size() > MB_ASYNC_SHM_KEY_SIZE || value.size() > MB_ASYNC_SHM_DATA_SIZE)
+        return Fail(db, db_dir, "test data exceeds queue node capacity", 4);
+
+    second.num_reader.store(1, std::memory_order_release);
+    reservation_time_ms[second_index].store(
+        SHMQ_GetMonotonicTimeMs(), std::memory_order_release);
+    std::copy(key.begin(), key.end(), second.key);
+    std::copy(value.begin(), value.end(), second.data);
+    second.key_len = static_cast<int>(key.size());
+    second.data_len = static_cast<int>(value.size());
+    second.overwrite = true;
+    second.type = MABAIN_ASYNC_TYPE_ADD;
+    second.in_use.store(true, std::memory_order_release);
+
+    auto start = std::chrono::steady_clock::now();
+    header->queue_index.store(base + 2, std::memory_order_release);
+    dict->SHMQ_Signal();
+
+    auto deadline = start + std::chrono::seconds(3);
+    while (second.in_use.load(std::memory_order_acquire)
+        && std::chrono::steady_clock::now() < deadline) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(5));
+    }
+    auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(
+        std::chrono::steady_clock::now() - start);
+
+    if (second.in_use.load(std::memory_order_acquire))
+        return Fail(db, db_dir, "writer did not advance past the stale reservation", 5);
+    if (elapsed.count() < 900 || elapsed.count() >= 2500)
+        return Fail(db, db_dir, "reservation was reclaimed outside the expected window", 6);
+    if (first.num_reader.load(std::memory_order_acquire) != 0)
+        return Fail(db, db_dir, "stale physical slot remained reserved", 7);
+    if (reservation_time_ms[first_index].load(std::memory_order_acquire) != 0)
+        return Fail(db, db_dir, "stale reservation timestamp was not cleared", 8);
+
+    uint16_t expected = 0;
+    if (!first.num_reader.compare_exchange_strong(expected, 1,
+            std::memory_order_acq_rel, std::memory_order_acquire)) {
+        return Fail(db, db_dir, "reclaimed physical slot could not be acquired", 9);
+    }
+    first.num_reader.store(0, std::memory_order_release);
+
+    db.reset();
+    ResourcePool::getInstance().RemoveAll();
+    std::filesystem::remove_all(db_dir, ec);
+    if (ec) {
+        std::cerr << "test passed, but cleanup failed: " << ec.message() << std::endl;
+        return 10;
+    }
+
+    std::cout << "shmq_reservation_timeout_test passed; stale slot reclaimed after "
+              << elapsed.count() << " ms" << std::endl;
+    return 0;
+}

--- a/src/unittest/async_input_validation_test.cpp
+++ b/src/unittest/async_input_validation_test.cpp
@@ -1,0 +1,115 @@
+/**
+ * Copyright (C) 2026 Cisco Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License, version 2,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <filesystem>
+#include <memory>
+#include <string>
+
+#include <gtest/gtest.h>
+
+#include "../db.h"
+#include "../dict.h"
+#include "../drm_base.h"
+#include "../error.h"
+#include "../mabain_consts.h"
+#include "../resource_pool.h"
+#include "../shm_queue_mgr.h"
+
+using namespace mabain;
+
+namespace {
+
+const char* const ASYNC_INPUT_TEST_DIR = "/var/tmp/mabain_async_input_validation_test";
+
+class AsyncInputValidationTest : public ::testing::Test {
+protected:
+    void SetUp() override
+    {
+        ResourcePool::getInstance().RemoveAll();
+        std::error_code ec;
+        std::filesystem::remove_all(ASYNC_INPUT_TEST_DIR, ec);
+        ASSERT_FALSE(ec);
+        std::filesystem::create_directories(ASYNC_INPUT_TEST_DIR, ec);
+        ASSERT_FALSE(ec);
+
+        db = std::make_unique<DB>(ASYNC_INPUT_TEST_DIR, CONSTS::WriterOptions());
+        ASSERT_TRUE(db->is_open());
+        dict = db->GetDictPtr();
+        ASSERT_NE(dict, nullptr);
+        header = dict->GetHeaderPtr();
+        ASSERT_NE(header, nullptr);
+    }
+
+    void TearDown() override
+    {
+        db.reset();
+        ResourcePool::getInstance().RemoveAll();
+        std::error_code ec;
+        std::filesystem::remove_all(ASYNC_INPUT_TEST_DIR, ec);
+        EXPECT_FALSE(ec);
+    }
+
+    std::unique_ptr<DB> db;
+    Dict* dict = nullptr;
+    IndexHeader* header = nullptr;
+};
+
+TEST_F(AsyncInputValidationTest, PublicAddRejectsInvalidPointersAndLengths)
+{
+    const char key[] = "key";
+    const char data[] = "data";
+    const uint32_t queue_index = header->queue_index.load(std::memory_order_acquire);
+
+    EXPECT_EQ(db->AddAsync(nullptr, 1, data, 1), MBError::INVALID_ARG);
+    EXPECT_EQ(db->AddAsync(key, 1, nullptr, 1), MBError::INVALID_ARG);
+    EXPECT_EQ(db->AddAsync(key, -1, data, 1), MBError::OUT_OF_BOUND);
+    EXPECT_EQ(db->AddAsync(key, 1, data, -1), MBError::OUT_OF_BOUND);
+    EXPECT_EQ(db->AddAsync(key, 0, data, 1), MBError::OUT_OF_BOUND);
+    EXPECT_EQ(db->AddAsync(key, 1, data, 0), MBError::OUT_OF_BOUND);
+    EXPECT_EQ(db->AddAsync(key, CONSTS::MAX_KEY_LENGHTH + 1, data, 1),
+        MBError::OUT_OF_BOUND);
+    EXPECT_EQ(db->AddAsync(key, 1, data, CONSTS::MAX_DATA_SIZE + 1),
+        MBError::OUT_OF_BOUND);
+
+    EXPECT_EQ(header->queue_index.load(std::memory_order_acquire), queue_index);
+}
+
+TEST_F(AsyncInputValidationTest, QueueBoundaryRejectsInvalidInputBeforeReservation)
+{
+    const char key[] = "key";
+    const char data[] = "data";
+    const uint32_t queue_index = header->queue_index.load(std::memory_order_acquire);
+
+    EXPECT_EQ(dict->SHMQ_Add(nullptr, 1, data, 1, false), MBError::INVALID_ARG);
+    EXPECT_EQ(dict->SHMQ_Add(key, 1, nullptr, 1, false), MBError::INVALID_ARG);
+    EXPECT_EQ(dict->SHMQ_Add(key, -1, data, 1, false), MBError::OUT_OF_BOUND);
+    EXPECT_EQ(dict->SHMQ_Add(key, 1, data, -1, false), MBError::OUT_OF_BOUND);
+    EXPECT_EQ(dict->SHMQ_Add(key, 0, data, 1, false), MBError::OUT_OF_BOUND);
+    EXPECT_EQ(dict->SHMQ_Add(key, 1, data, 0, false), MBError::OUT_OF_BOUND);
+    EXPECT_EQ(dict->SHMQ_Add(key, MB_ASYNC_SHM_KEY_SIZE + 1, data, 1, false),
+        MBError::OUT_OF_BOUND);
+    EXPECT_EQ(dict->SHMQ_Add(key, 1, data, MB_ASYNC_SHM_DATA_SIZE + 1, false),
+        MBError::OUT_OF_BOUND);
+    EXPECT_EQ(dict->SHMQ_Remove(nullptr, 1), MBError::INVALID_ARG);
+    EXPECT_EQ(dict->SHMQ_Remove(key, -1), MBError::OUT_OF_BOUND);
+    EXPECT_EQ(dict->SHMQ_Remove(key, 0), MBError::OUT_OF_BOUND);
+    EXPECT_EQ(dict->SHMQ_Remove(key, MB_ASYNC_SHM_KEY_SIZE + 1),
+        MBError::OUT_OF_BOUND);
+
+    EXPECT_EQ(header->queue_index.load(std::memory_order_acquire), queue_index);
+}
+
+} // namespace

--- a/src/unittest/async_writer_deadline_test.cpp
+++ b/src/unittest/async_writer_deadline_test.cpp
@@ -1,0 +1,244 @@
+/**
+ * Copyright (C) 2026 Cisco Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2.
+ */
+
+#include <algorithm>
+#include <chrono>
+#include <filesystem>
+#include <string>
+#include <system_error>
+#include <thread>
+#include <unistd.h>
+
+#include <gtest/gtest.h>
+
+#include "../db.h"
+#include "../detail/search_engine.h"
+#include "../dict.h"
+#include "../resource_pool.h"
+#include "../shm_queue_mgr.h"
+
+using namespace mabain;
+
+namespace {
+
+class AsyncWriterDeadlineTest : public ::testing::Test {
+protected:
+    void SetUp() override
+    {
+        db_dir = "/var/tmp/mabain_async_deadline_test_" + std::to_string(getpid());
+        db_path = db_dir + "/";
+
+        std::error_code ec;
+        std::filesystem::remove_all(db_dir, ec);
+        ec.clear();
+        ASSERT_TRUE(std::filesystem::create_directories(db_dir, ec));
+        ASSERT_FALSE(ec);
+
+        MBConfig config = { 0 };
+        config.mbdir = db_path.c_str();
+        config.options = CONSTS::WriterOptions() | CONSTS::ASYNC_WRITER_MODE;
+        config.memcap_index = 64 * 1024 * 1024LL;
+        config.memcap_data = 64 * 1024 * 1024LL;
+        config.queue_size = 4;
+        config.queue_dir = db_dir.c_str();
+        config.async_queue_reservation_timeout_sec = 2;
+
+        db = new DB(config);
+        ASSERT_TRUE(db->is_open()) << db->StatusStr();
+        dict = db->GetDictPtr();
+        ASSERT_NE(dict, nullptr);
+        header = dict->GetHeaderPtr();
+        queue = dict->GetAsyncQueuePtr();
+        reservation_time_ms = dict->GetAsyncQueueReservationTimePtr();
+        ASSERT_NE(header, nullptr);
+        ASSERT_NE(queue, nullptr);
+        ASSERT_NE(reservation_time_ms, nullptr);
+
+        // Let the async writer enter its idle wait before injecting a gap.
+        std::this_thread::sleep_for(std::chrono::milliseconds(50));
+    }
+
+    void TearDown() override
+    {
+        delete db;
+        db = nullptr;
+        ResourcePool::getInstance().RemoveAll();
+
+        std::error_code ec;
+        std::filesystem::remove_all(db_dir, ec);
+    }
+
+    void FillAdd(AsyncNode& node, const std::string& key, const std::string& value)
+    {
+        ASSERT_LE(key.size(), static_cast<size_t>(MB_ASYNC_SHM_KEY_SIZE));
+        ASSERT_LE(value.size(), static_cast<size_t>(MB_ASYNC_SHM_DATA_SIZE));
+
+        std::copy(key.begin(), key.end(), node.key);
+        std::copy(value.begin(), value.end(), node.data);
+        node.key_len = static_cast<int>(key.size());
+        node.data_len = static_cast<int>(value.size());
+        node.overwrite = true;
+        node.type = MABAIN_ASYNC_TYPE_ADD;
+    }
+
+    bool WaitUntilReleased(const AsyncNode& node, std::chrono::milliseconds timeout)
+    {
+        auto deadline = std::chrono::steady_clock::now() + timeout;
+        while (std::chrono::steady_clock::now() < deadline) {
+            if (!node.in_use.load(std::memory_order_acquire))
+                return true;
+            std::this_thread::sleep_for(std::chrono::milliseconds(5));
+        }
+        return !node.in_use.load(std::memory_order_acquire);
+    }
+
+    bool WaitUntilReservationStarted(uint32_t slot_index,
+        std::chrono::milliseconds timeout)
+    {
+        auto deadline = std::chrono::steady_clock::now() + timeout;
+        while (std::chrono::steady_clock::now() < deadline) {
+            if (reservation_time_ms[slot_index].load(std::memory_order_acquire) != 0)
+                return true;
+            std::this_thread::sleep_for(std::chrono::milliseconds(1));
+        }
+        return reservation_time_ms[slot_index].load(std::memory_order_acquire) != 0;
+    }
+
+    void ReserveFirstAndPublishSecond(AsyncNode*& first, AsyncNode*& second,
+        const std::string& key, const std::string& second_value)
+    {
+        uint32_t base = header->queue_index.load(std::memory_order_acquire);
+        first = &queue[base % header->async_queue_size];
+        second = &queue[(base + 1) % header->async_queue_size];
+
+        first->num_reader.store(1, std::memory_order_release);
+        reservation_time_ms[base % header->async_queue_size].store(
+            SHMQ_GetMonotonicTimeMs(), std::memory_order_release);
+        second->num_reader.store(1, std::memory_order_release);
+        reservation_time_ms[(base + 1) % header->async_queue_size].store(
+            SHMQ_GetMonotonicTimeMs(), std::memory_order_release);
+        FillAdd(*second, key, second_value);
+        second->in_use.store(true, std::memory_order_release);
+        header->queue_index.store(base + 2, std::memory_order_release);
+        dict->SHMQ_Signal();
+    }
+
+    DB* db = nullptr;
+    Dict* dict = nullptr;
+    IndexHeader* header = nullptr;
+    AsyncNode* queue = nullptr;
+    std::atomic<uint64_t>* reservation_time_ms = nullptr;
+    std::string db_dir;
+    std::string db_path;
+};
+
+TEST_F(AsyncWriterDeadlineTest, UsesConfiguredReservationTimeout)
+{
+    MBConfig config = { 0 };
+    db->GetDBConfig(config);
+
+    EXPECT_EQ(config.async_queue_reservation_timeout_sec, 2U);
+    EXPECT_EQ(CONSTS::DEFAULT_ASYNC_QUEUE_RESERVATION_TIMEOUT_SEC, 3600);
+}
+
+TEST_F(AsyncWriterDeadlineTest, PreReservationGapUsesConfiguredTimeout)
+{
+    const std::string key = "delayed-reservation-key";
+    AsyncNode* first = nullptr;
+    AsyncNode* second = nullptr;
+    uint32_t base = header->queue_index.load(std::memory_order_acquire);
+    first = &queue[base % header->async_queue_size];
+    second = &queue[(base + 1) % header->async_queue_size];
+
+    second->num_reader.store(1, std::memory_order_release);
+    reservation_time_ms[(base + 1) % header->async_queue_size].store(
+        SHMQ_GetMonotonicTimeMs(), std::memory_order_release);
+    FillAdd(*second, key, "second");
+    second->in_use.store(true, std::memory_order_release);
+    header->queue_index.store(base + 2, std::memory_order_release);
+    dict->SHMQ_Signal();
+
+    // Anchor the delay to the writer observing the unpublished first slot.
+    // Without this synchronization, late writer scheduling could let the old
+    // one-second grace implementation pass without exercising its timeout.
+    ASSERT_TRUE(WaitUntilReservationStarted(base % header->async_queue_size,
+        std::chrono::seconds(3)));
+
+    // This exceeds the old hard-coded one-second grace but remains below the
+    // configured two-second reservation timeout.
+    std::this_thread::sleep_for(std::chrono::milliseconds(1200));
+    EXPECT_TRUE(second->in_use.load(std::memory_order_acquire));
+
+    first->num_reader.store(1, std::memory_order_release);
+    reservation_time_ms[base % header->async_queue_size].store(
+        SHMQ_GetMonotonicTimeMs(), std::memory_order_release);
+    FillAdd(*first, key, "first");
+    first->in_use.store(true, std::memory_order_release);
+    dict->SHMQ_Signal();
+
+    ASSERT_TRUE(WaitUntilReleased(*first, std::chrono::seconds(3)));
+    ASSERT_TRUE(WaitUntilReleased(*second, std::chrono::seconds(3)));
+}
+
+TEST_F(AsyncWriterDeadlineTest, LaterSignalDoesNotSkipEarlierSlot)
+{
+    const std::string key = "deadline-order-key";
+    const std::string first_value = "first";
+    const std::string second_value = "second";
+    AsyncNode* first = nullptr;
+    AsyncNode* second = nullptr;
+
+    ReserveFirstAndPublishSecond(first, second, key, second_value);
+
+    // Repeated signals must not restart or bypass the first slot's deadline.
+    for (int i = 0; i < 20; ++i) {
+        dict->SHMQ_Signal();
+        std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    }
+    EXPECT_TRUE(second->in_use.load(std::memory_order_acquire));
+
+    FillAdd(*first, key, first_value);
+    first->in_use.store(true, std::memory_order_release);
+    dict->SHMQ_Signal();
+
+    ASSERT_TRUE(WaitUntilReleased(*first, std::chrono::seconds(2)));
+    ASSERT_TRUE(WaitUntilReleased(*second, std::chrono::seconds(2)));
+
+    MBData data;
+    detail::SearchEngine engine(*dict);
+    ASSERT_EQ(engine.find(reinterpret_cast<const uint8_t*>(key.data()),
+                  static_cast<int>(key.size()), data),
+        MBError::SUCCESS);
+    EXPECT_EQ(std::string(reinterpret_cast<const char*>(data.buff), data.data_len),
+        second_value);
+}
+
+TEST_F(AsyncWriterDeadlineTest, UnfinishedSlotIsSkippedAfterDeadline)
+{
+    const std::string key = "deadline-timeout-key";
+    AsyncNode* first = nullptr;
+    AsyncNode* second = nullptr;
+
+    auto start = std::chrono::steady_clock::now();
+    ReserveFirstAndPublishSecond(first, second, key, "second");
+    ASSERT_TRUE(WaitUntilReleased(*second, std::chrono::seconds(4)));
+    auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(
+        std::chrono::steady_clock::now() - start);
+
+    EXPECT_GE(elapsed.count(), 1900);
+    EXPECT_LT(elapsed.count(), 3500);
+    EXPECT_FALSE(first->in_use.load(std::memory_order_acquire));
+    EXPECT_EQ(first->num_reader.load(std::memory_order_acquire), 0);
+    EXPECT_EQ(reservation_time_ms[first - queue].load(std::memory_order_acquire), 0U);
+
+    uint16_t expected = 0;
+    EXPECT_TRUE(first->num_reader.compare_exchange_strong(expected, 1,
+        std::memory_order_acq_rel, std::memory_order_acquire));
+    first->num_reader.store(0, std::memory_order_release);
+}
+
+} // namespace

--- a/src/unittest/db_constructor_test.cpp
+++ b/src/unittest/db_constructor_test.cpp
@@ -1,0 +1,59 @@
+/**
+ * Copyright (C) 2026 Cisco Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License, version 2,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <array>
+#include <new>
+
+#include <gtest/gtest.h>
+
+#include "../db.h"
+#include "../error.h"
+#include "../mabain_consts.h"
+
+using namespace mabain;
+
+TEST(DBConstructorTest, NullPathLeavesObjectSafeToDestroy)
+{
+    // Make missing initialization deterministic instead of depending on stack contents.
+    alignas(DB) std::array<unsigned char, sizeof(DB)> storage;
+    storage.fill(0xA5);
+
+    DB* db = new (storage.data()) DB(nullptr, CONSTS::WriterOptions());
+    const int status = db->Status();
+    const int options = db->GetDBOptions();
+    Dict* const dict = db->GetDictPtr();
+    const bool db_dir_empty = db->GetDBDir().empty();
+    MBConfig config;
+    db->GetDBConfig(config);
+
+    // Destruction is part of the regression: Close() must see only safe defaults.
+    db->~DB();
+
+    EXPECT_EQ(status, MBError::NOT_INITIALIZED);
+    EXPECT_EQ(options, 0);
+    EXPECT_EQ(dict, nullptr);
+    EXPECT_TRUE(db_dir_empty);
+    EXPECT_EQ(config.mbdir, nullptr);
+    EXPECT_EQ(config.options, 0);
+    EXPECT_EQ(config.memcap_index, 0u);
+    EXPECT_EQ(config.memcap_data, 0u);
+    EXPECT_EQ(config.data_size, 0);
+    EXPECT_EQ(config.connect_id, 0u);
+    EXPECT_EQ(config.queue_size, 0u);
+    EXPECT_EQ(config.queue_dir, nullptr);
+    EXPECT_FALSE(config.jemalloc_keep_db);
+    EXPECT_EQ(config.async_queue_reservation_timeout_sec, 0u);
+}

--- a/src/unittest/jemalloc_rebuild_test.cpp
+++ b/src/unittest/jemalloc_rebuild_test.cpp
@@ -6,13 +6,16 @@
  * as published by the Free Software Foundation.
  */
 
+#include <cerrno>
 #include <cstddef>
 #include <cstdlib>
 #include <cstring>
+#include <fcntl.h>
 #include <filesystem>
 #include <fstream>
 #include <sstream>
 #include <string>
+#include <sys/file.h>
 #include <vector>
 #include <unistd.h>
 
@@ -177,6 +180,16 @@ public:
     static void EndReaderEpochGuard(DB& db, uint64_t epoch)
     {
         db.EndReaderEpochGuard(epoch);
+    }
+
+    static int AcquireRebuildBarrierShared(DB& db)
+    {
+        return db.AcquireRebuildBarrierShared();
+    }
+
+    static void ReleaseRebuildBarrierShared(DB& db)
+    {
+        db.ReleaseRebuildBarrierShared();
     }
 };
 
@@ -364,6 +377,81 @@ TEST_F(JemallocRebuildMetadataTest, ReaderEpochGuardEndClearsClaimedSlot)
     ASSERT_NE(token, 0u);
     mabain::DBTestPeer::EndReaderEpochGuard(reader_db, token);
     EXPECT_EQ(header->reader_epoch_slot[token - 1].connect_id.load(MEMORY_ORDER_READER), 0u);
+    EXPECT_EQ(header->reader_epoch_slot[token - 1].pid.load(MEMORY_ORDER_READER), 0u);
+    EXPECT_EQ(header->reader_epoch_slot[token - 1].proc_start_time.load(MEMORY_ORDER_READER), 0u);
+    EXPECT_EQ(header->reader_epoch_slot[token - 1].epoch.load(MEMORY_ORDER_READER), 0u);
+}
+
+TEST_F(JemallocRebuildMetadataTest, StaleReaderClearRejectsReusedProcessIdentity)
+{
+    ReaderEpochSlot slot {};
+    slot.connect_id.store(17, MEMORY_ORDER_WRITER);
+    slot.pid.store(101, MEMORY_ORDER_WRITER);
+    slot.proc_start_time.store(1001, MEMORY_ORDER_WRITER);
+    slot.epoch.store(9, MEMORY_ORDER_WRITER);
+
+    // Simulate PID/connect-id/epoch reuse after the writer captured the old
+    // identity. The process start time is the field that distinguishes it.
+    slot.proc_start_time.store(1002, MEMORY_ORDER_WRITER);
+
+    EXPECT_FALSE(slot.TryClearStale(17, 101, 1001, 9));
+    EXPECT_EQ(slot.connect_id.load(MEMORY_ORDER_READER), 17u);
+    EXPECT_EQ(slot.pid.load(MEMORY_ORDER_READER), 101u);
+    EXPECT_EQ(slot.proc_start_time.load(MEMORY_ORDER_READER), 1002u);
+    EXPECT_EQ(slot.epoch.load(MEMORY_ORDER_READER), 9u);
+}
+
+TEST_F(JemallocRebuildMetadataTest, StaleReaderClearClearsMatchingSlot)
+{
+    ReaderEpochSlot slot {};
+    slot.connect_id.store(17, MEMORY_ORDER_WRITER);
+    slot.pid.store(101, MEMORY_ORDER_WRITER);
+    slot.proc_start_time.store(1001, MEMORY_ORDER_WRITER);
+    slot.epoch.store(9, MEMORY_ORDER_WRITER);
+
+    EXPECT_TRUE(slot.TryClearStale(17, 101, 1001, 9));
+    EXPECT_EQ(slot.connect_id.load(MEMORY_ORDER_READER), 0u);
+    EXPECT_EQ(slot.pid.load(MEMORY_ORDER_READER), 0u);
+    EXPECT_EQ(slot.proc_start_time.load(MEMORY_ORDER_READER), 0u);
+    EXPECT_EQ(slot.epoch.load(MEMORY_ORDER_READER), 0u);
+}
+
+TEST_F(JemallocRebuildMetadataTest, FallbackBarrierRemainsLockedUntilLastReader)
+{
+    MBConfig writer_config = MakeJemallocRebuildConfig(
+        CONSTS::ACCESS_MODE_WRITER | CONSTS::OPTION_JEMALLOC, false);
+    DB writer_db(writer_config);
+    ASSERT_TRUE(writer_db.is_open());
+
+    MBConfig reader_config = MakeJemallocRebuildConfig(
+        CONSTS::ACCESS_MODE_READER | CONSTS::OPTION_JEMALLOC, false);
+    DB reader1(reader_config);
+    DB reader2(reader_config);
+    ASSERT_TRUE(reader1.is_open());
+    ASSERT_TRUE(reader2.is_open());
+
+    ASSERT_EQ(mabain::DBTestPeer::AcquireRebuildBarrierShared(reader1), MBError::SUCCESS);
+    if (mabain::DBTestPeer::AcquireRebuildBarrierShared(reader2) != MBError::SUCCESS) {
+        mabain::DBTestPeer::ReleaseRebuildBarrierShared(reader1);
+        FAIL() << "second reader failed to acquire rebuild barrier";
+    }
+    mabain::DBTestPeer::ReleaseRebuildBarrierShared(reader1);
+
+    const std::string header_path = reader1.GetDBDir() + "_mabain_h";
+    int probe_fd = open(header_path.c_str(), O_RDWR);
+    if (probe_fd < 0) {
+        mabain::DBTestPeer::ReleaseRebuildBarrierShared(reader2);
+        FAIL() << "failed to open rebuild barrier probe";
+    }
+
+    errno = 0;
+    EXPECT_EQ(flock(probe_fd, LOCK_EX | LOCK_NB), -1);
+    EXPECT_TRUE(errno == EWOULDBLOCK || errno == EAGAIN);
+
+    mabain::DBTestPeer::ReleaseRebuildBarrierShared(reader2);
+    EXPECT_EQ(flock(probe_fd, LOCK_EX | LOCK_NB), 0);
+    EXPECT_EQ(flock(probe_fd, LOCK_UN), 0);
+    EXPECT_EQ(close(probe_fd), 0);
 }
 
 TEST_F(JemallocRebuildMetadataTest, RunStartupRebuildOnReaderReturnsControlledError)

--- a/src/unittest/logger_test.cpp
+++ b/src/unittest/logger_test.cpp
@@ -1,0 +1,59 @@
+/**
+ * Copyright (C) 2026 Cisco Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License, version 2,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <cstdio>
+#include <fstream>
+#include <string>
+
+#include <gtest/gtest.h>
+
+#include "../db.h"
+#include "../logger.h"
+
+namespace {
+
+const char* const MAIN_LOG_FILE = "/var/tmp/mabain_test/mabain.log";
+const char* const BOUNDS_TEST_LOG_FILE = "/var/tmp/mabain_test/logger_bounds_test.log";
+
+}
+
+TEST(LoggerTest, FormattedMessageIsBounded)
+{
+    mabain::DB::CloseLogFile();
+    std::remove(BOUNDS_TEST_LOG_FILE);
+    mabain::DB::SetLogFile(BOUNDS_TEST_LOG_FILE);
+
+    const std::string oversized_message(1024, 'x');
+    mabain::Logger::Log(LOG_LEVEL_INFO, "%s", oversized_message.c_str());
+
+    mabain::DB::CloseLogFile();
+    std::ifstream log(BOUNDS_TEST_LOG_FILE);
+    std::string line;
+    const bool read_ok = static_cast<bool>(std::getline(log, line));
+    log.close();
+    std::remove(BOUNDS_TEST_LOG_FILE);
+
+    // Restore the log used by the shared unit-test process before asserting.
+    mabain::DB::SetLogFile(MAIN_LOG_FILE);
+
+    ASSERT_TRUE(read_ok);
+    const std::string truncated_message(255, 'x');
+    ASSERT_GE(line.size(), truncated_message.size());
+    EXPECT_EQ(line.compare(line.size() - truncated_message.size(),
+                  truncated_message.size(), truncated_message),
+        0);
+    EXPECT_EQ(line.find(std::string(256, 'x')), std::string::npos);
+}

--- a/src/unittest/prefix_cache_test.cpp
+++ b/src/unittest/prefix_cache_test.cpp
@@ -106,6 +106,42 @@ TEST_F(PrefixCacheTest, PutOnAdd)
     EXPECT_EQ(n, 3); // shared cache supports up to 3-byte seeds
 }
 
+TEST_F(PrefixCacheTest, AsyncWriterSeedsSharedCache)
+{
+    db->Close();
+    delete db;
+    db = nullptr;
+    ResourcePool::getInstance().RemoveAll();
+
+    std::string cmd = std::string("rm -f ") + MB_DIR + "_*";
+    ASSERT_EQ(system(cmd.c_str()), 0);
+
+    db = new DB(MB_DIR, CONSTS::WriterOptions()
+            | CONSTS::ASYNC_WRITER_MODE | CONSTS::OPTION_PREFIX_CACHE);
+    ASSERT_NE(db, nullptr);
+    ASSERT_TRUE(db->is_open());
+
+    PrefixCache* pc = db->GetDictPtr()->ActivePrefixCache();
+    ASSERT_NE(pc, nullptr);
+
+    const std::string key = "async-prefix-key";
+    const std::string value = "async-value";
+    ASSERT_EQ(db->Add(key, value, false), MBError::SUCCESS);
+
+    PrefixCacheEntry out {};
+    EXPECT_GT(pc->GetDepth(reinterpret_cast<const uint8_t*>(key.data()),
+                  static_cast<int>(key.size()), out),
+        0);
+
+    DB cached_reader(MB_DIR,
+        CONSTS::ReaderOptions() | CONSTS::OPTION_PREFIX_CACHE);
+    ASSERT_TRUE(cached_reader.is_open());
+    MBData data;
+    ASSERT_EQ(cached_reader.Find(key, data), MBError::SUCCESS);
+    EXPECT_EQ(std::string(reinterpret_cast<const char*>(data.buff), data.data_len),
+        value);
+}
+
 TEST_F(PrefixCacheTest, NoPutOnFind)
 {
     // Seed via Add first
@@ -171,6 +207,43 @@ TEST_F(PrefixCacheTest, SeedFromCache_GetDepth)
     EXPECT_EQ(n4, 0);
 }
 
+TEST_F(PrefixCacheTest, LongCompressedEdgeSeedsAllCanonicalDepths)
+{
+    const std::string key = "fixed-prefix-key";
+    ASSERT_EQ(db->Add(key, key, false), MBError::SUCCESS);
+
+    PrefixCache* pc = db->GetDictPtr()->ActivePrefixCache();
+    ASSERT_NE(pc, nullptr);
+
+    PrefixCacheEntry out {};
+    EXPECT_EQ(pc->GetDepth(reinterpret_cast<const uint8_t*>(key.data()), 2, out), 2);
+    EXPECT_EQ(pc->GetDepth(reinterpret_cast<const uint8_t*>(key.data()), 3, out), 3);
+    EXPECT_EQ(pc->GetDepth(reinterpret_cast<const uint8_t*>(key.data()), 4, out), 4);
+}
+
+TEST_F(PrefixCacheTest, FoldedFourByteIndexDistributesFixedLeadingPrefixes)
+{
+    PrefixCache* pc = db->GetDictPtr()->ActivePrefixCache();
+    ASSERT_NE(pc, nullptr);
+    ASSERT_GT(pc->Cap4(), 0u);
+
+    const uint8_t key1[] = { 'A', 'A', 0, 0 };
+    const uint8_t key2[] = { 'A', 'A', 1, 0 };
+    PrefixCacheEntry seed1 {};
+    PrefixCacheEntry seed2 {};
+    seed1.edge_offset = 111;
+    seed2.edge_offset = 222;
+
+    pc->PutAtDepth(key1, 4, seed1);
+    pc->PutAtDepth(key2, 4, seed2);
+
+    PrefixCacheEntry out {};
+    ASSERT_EQ(pc->GetDepth(key1, 4, out), 4);
+    EXPECT_EQ(out.edge_offset, seed1.edge_offset);
+    ASSERT_EQ(pc->GetDepth(key2, 4, out), 4);
+    EXPECT_EQ(out.edge_offset, seed2.edge_offset);
+}
+
 TEST_F(PrefixCacheTest, OverwriteBetweenCounterChecksIsRejected)
 {
     Dict* dict = db->GetDictPtr();
@@ -205,6 +278,248 @@ TEST_F(PrefixCacheTest, OverwriteBetweenCounterChecksIsRejected)
         0);
     EXPECT_EQ(stable.edge_skip, new_entry.edge_skip);
     EXPECT_EQ(stable.lf_counter, 3u); // old and new origin bits are preserved
+}
+
+TEST_F(PrefixCacheTest, HierarchicalInvalidationIsScoped)
+{
+    PrefixCache* pc = db->GetDictPtr()->ActivePrefixCache();
+    ASSERT_NE(pc, nullptr);
+
+    const uint8_t ab[] = { 'A', 'B' };
+    const uint8_t ac[] = { 'A', 'C' };
+    const uint8_t zb[] = { 'Z', 'B' };
+    PrefixCacheEntry seed {};
+    seed.edge_offset = 123;
+
+    pc->PutAtDepth(ab, 2, seed);
+    pc->PutAtDepth(ac, 2, seed);
+    pc->PutAtDepth(zb, 2, seed);
+
+    PrefixCacheEntry out {};
+    ASSERT_EQ(pc->GetDepth(ab, 2, out), 2);
+    ASSERT_EQ(pc->GetDepth(ac, 2, out), 2);
+    ASSERT_EQ(pc->GetDepth(zb, 2, out), 2);
+
+    pc->InvalidatePrefix2(ab, 2);
+    EXPECT_EQ(pc->GetDepth(ab, 2, out), 0);
+    EXPECT_EQ(pc->GetDepth(ac, 2, out), 2);
+    EXPECT_EQ(pc->GetDepth(zb, 2, out), 2);
+
+    pc->PutAtDepth(ab, 2, seed);
+    pc->InvalidateRoot('A');
+    EXPECT_EQ(pc->GetDepth(ab, 2, out), 0);
+    EXPECT_EQ(pc->GetDepth(ac, 2, out), 0);
+    EXPECT_EQ(pc->GetDepth(zb, 2, out), 2);
+
+    pc->PutAtDepth(ab, 2, seed);
+    pc->PutAtDepth(ac, 2, seed);
+    pc->InvalidateAll();
+    EXPECT_EQ(pc->GetDepth(ab, 2, out), 0);
+    EXPECT_EQ(pc->GetDepth(ac, 2, out), 0);
+    EXPECT_EQ(pc->GetDepth(zb, 2, out), 0);
+}
+
+TEST_F(PrefixCacheTest, RemoveCannotReadValueFromReusedDataOffset)
+{
+    const std::string removed_key("ABCD", 4);
+    const std::string replacement_key("WXYZ", 4);
+    const std::string old_value("value-two", 9);
+    const std::string replacement_value("new-value", 9);
+
+    ASSERT_EQ(db->Add(removed_key, "value-one", false), MBError::SUCCESS);
+    ASSERT_EQ(db->Add(removed_key, old_value, true), MBError::SUCCESS);
+
+    DB cached_reader(MB_DIR,
+        CONSTS::ReaderOptions() | CONSTS::OPTION_PREFIX_CACHE);
+    ASSERT_TRUE(cached_reader.is_open());
+
+    MBData before;
+    ASSERT_EQ(cached_reader.Find(removed_key, before), MBError::SUCCESS);
+    ASSERT_EQ(std::string(reinterpret_cast<const char*>(before.buff),
+                  before.data_len),
+        old_value);
+
+    ASSERT_EQ(db->Remove(removed_key), MBError::SUCCESS);
+    ASSERT_EQ(db->Add(replacement_key, replacement_value, false),
+        MBError::SUCCESS);
+
+    MBData removed;
+    EXPECT_EQ(cached_reader.Find(removed_key, removed), MBError::NOT_EXIST);
+
+    DB fresh_cached_reader(MB_DIR,
+        CONSTS::ReaderOptions() | CONSTS::OPTION_PREFIX_CACHE);
+    ASSERT_TRUE(fresh_cached_reader.is_open());
+    removed.Clear();
+    EXPECT_EQ(fresh_cached_reader.Find(removed_key, removed),
+        MBError::NOT_EXIST);
+
+    MBData replacement;
+    ASSERT_EQ(cached_reader.Find(replacement_key, replacement),
+        MBError::SUCCESS);
+    EXPECT_EQ(std::string(reinterpret_cast<const char*>(replacement.buff),
+                  replacement.data_len),
+        replacement_value);
+}
+
+TEST_F(PrefixCacheTest, StructuralRemoveInvalidatesOnlyNecessaryScope)
+{
+    const std::string abcd = "ABCD";
+    const std::string abce = "ABCE";
+    const std::string aczz = "ACZZ";
+
+    ASSERT_EQ(db->Add(abcd, abcd, false), MBError::SUCCESS);
+    ASSERT_EQ(db->Add(abce, abce, false), MBError::SUCCESS);
+    ASSERT_EQ(db->Add(aczz, aczz, false), MBError::SUCCESS);
+    ASSERT_EQ(db->Add(abcd, abcd, true), MBError::SUCCESS);
+    ASSERT_EQ(db->Add(abce, abce, true), MBError::SUCCESS);
+    ASSERT_EQ(db->Add(aczz, aczz, true), MBError::SUCCESS);
+
+    PrefixCache* pc = db->GetDictPtr()->ActivePrefixCache();
+    ASSERT_NE(pc, nullptr);
+    PrefixCacheEntry out {};
+    ASSERT_GT(pc->GetDepth(reinterpret_cast<const uint8_t*>(abce.data()),
+                  static_cast<int>(abce.size()), out),
+        0);
+    ASSERT_GT(pc->GetDepth(reinterpret_cast<const uint8_t*>(aczz.data()),
+                  static_cast<int>(aczz.size()), out),
+        0);
+
+    ASSERT_EQ(db->Remove(abcd), MBError::SUCCESS);
+
+    // The rebuilt AB subtree invalidates its two-byte generation. The AC
+    // partition shares byte 0 but remains valid because the first child node
+    // itself was not rebuilt.
+    EXPECT_EQ(pc->GetDepth(reinterpret_cast<const uint8_t*>(abce.data()),
+                  static_cast<int>(abce.size()), out),
+        0);
+    EXPECT_GT(pc->GetDepth(reinterpret_cast<const uint8_t*>(aczz.data()),
+                  static_cast<int>(aczz.size()), out),
+        0);
+
+    DB cached_reader(MB_DIR,
+        CONSTS::ReaderOptions() | CONSTS::OPTION_PREFIX_CACHE);
+    ASSERT_TRUE(cached_reader.is_open());
+    MBData data;
+    EXPECT_EQ(cached_reader.Find(abcd, data), MBError::NOT_EXIST);
+    data.Clear();
+    EXPECT_EQ(cached_reader.Find(abce, data), MBError::SUCCESS);
+    data.Clear();
+    EXPECT_EQ(cached_reader.Find(aczz, data), MBError::SUCCESS);
+}
+
+TEST_F(PrefixCacheTest, ShallowStructuralRemoveInvalidatesFirstByteScope)
+{
+    const std::string ab = "AB";
+    const std::string ac = "AC";
+    const std::string zb = "ZB";
+
+    ASSERT_EQ(db->Add(ab, ab, false), MBError::SUCCESS);
+    ASSERT_EQ(db->Add(ac, ac, false), MBError::SUCCESS);
+    ASSERT_EQ(db->Add(zb, zb, false), MBError::SUCCESS);
+
+    PrefixCache* pc = db->GetDictPtr()->ActivePrefixCache();
+    ASSERT_NE(pc, nullptr);
+    PrefixCacheEntry seed {};
+    seed.edge_offset = 123;
+    pc->PutAtDepth(reinterpret_cast<const uint8_t*>(ab.data()), 2, seed);
+    pc->PutAtDepth(reinterpret_cast<const uint8_t*>(ac.data()), 2, seed);
+    PrefixCacheEntry out {};
+    ASSERT_EQ(pc->GetDepth(reinterpret_cast<const uint8_t*>(ab.data()), 2, out), 2);
+    ASSERT_EQ(pc->GetDepth(reinterpret_cast<const uint8_t*>(ac.data()), 2, out), 2);
+    ASSERT_EQ(pc->GetDepth(reinterpret_cast<const uint8_t*>(zb.data()), 2, out), 2);
+
+    ASSERT_EQ(db->Remove(ab), MBError::SUCCESS);
+
+    EXPECT_EQ(pc->GetDepth(reinterpret_cast<const uint8_t*>(ab.data()), 2, out), 0);
+    EXPECT_EQ(pc->GetDepth(reinterpret_cast<const uint8_t*>(ac.data()), 2, out), 0);
+    EXPECT_EQ(pc->GetDepth(reinterpret_cast<const uint8_t*>(zb.data()), 2, out), 2);
+
+    DB cached_reader(MB_DIR,
+        CONSTS::ReaderOptions() | CONSTS::OPTION_PREFIX_CACHE);
+    ASSERT_TRUE(cached_reader.is_open());
+    MBData data;
+    EXPECT_EQ(cached_reader.Find(ab, data), MBError::NOT_EXIST);
+    data.Clear();
+    EXPECT_EQ(cached_reader.Find(ac, data), MBError::SUCCESS);
+    data.Clear();
+    EXPECT_EQ(cached_reader.Find(zb, data), MBError::SUCCESS);
+}
+
+TEST_F(PrefixCacheTest, RemoveAllInvalidatesCachedOffsetsBeforeReuse)
+{
+    const std::string old_key = "ABCD";
+    const std::string new_key = "WXYZ";
+    const std::string old_value = "old-value";
+    const std::string new_value = "new-value";
+
+    ASSERT_EQ(db->Add(old_key, old_value, false), MBError::SUCCESS);
+
+    DB cached_reader(MB_DIR,
+        CONSTS::ReaderOptions() | CONSTS::OPTION_PREFIX_CACHE);
+    ASSERT_TRUE(cached_reader.is_open());
+    MBData data;
+    ASSERT_EQ(cached_reader.Find(old_key, data), MBError::SUCCESS);
+
+    ASSERT_EQ(db->RemoveAll(), MBError::SUCCESS);
+    ASSERT_EQ(db->Add(new_key, new_value, false), MBError::SUCCESS);
+
+    data.Clear();
+    EXPECT_EQ(cached_reader.Find(old_key, data), MBError::NOT_EXIST);
+    data.Clear();
+    ASSERT_EQ(cached_reader.Find(new_key, data), MBError::SUCCESS);
+    EXPECT_EQ(std::string(reinterpret_cast<const char*>(data.buff), data.data_len),
+        new_value);
+}
+
+TEST_F(PrefixCacheTest, JemallocRemoveAllPreservesEmbeddedCacheRegion)
+{
+    db->Close();
+    delete db;
+    db = nullptr;
+    ResourcePool::getInstance().RemoveAll();
+
+    std::string cmd = std::string("rm -f ") + MB_DIR + "_*";
+    ASSERT_EQ(system(cmd.c_str()), 0);
+
+    constexpr uint32_t block_size = 32 * 1024 * 1024;
+    MBConfig writer_config = {};
+    writer_config.mbdir = MB_DIR;
+    writer_config.options = CONSTS::WriterOptions()
+        | CONSTS::OPTION_JEMALLOC | CONSTS::OPTION_PREFIX_CACHE;
+    writer_config.block_size_index = block_size;
+    writer_config.block_size_data = block_size;
+    writer_config.max_num_index_block = 1;
+    writer_config.max_num_data_block = 1;
+    writer_config.memcap_index = block_size;
+    writer_config.memcap_data = block_size;
+    writer_config.num_entry_per_bucket = 500;
+    writer_config.jemalloc_keep_db = true;
+    db = new DB(writer_config);
+    ASSERT_NE(db, nullptr);
+    ASSERT_TRUE(db->is_open());
+    ASSERT_NE(db->GetDictPtr()->ActivePrefixCache(), nullptr);
+
+    const std::string old_key = "ABCD";
+    const std::string new_key = "WXYZ";
+    ASSERT_EQ(db->Add(old_key, "old-value", false), MBError::SUCCESS);
+
+    MBConfig reader_config = writer_config;
+    reader_config.options = CONSTS::ReaderOptions()
+        | CONSTS::OPTION_JEMALLOC | CONSTS::OPTION_PREFIX_CACHE;
+    DB cached_reader(reader_config);
+    ASSERT_TRUE(cached_reader.is_open());
+    MBData data;
+    ASSERT_EQ(cached_reader.Find(old_key, data), MBError::SUCCESS);
+
+    ASSERT_EQ(db->RemoveAll(), MBError::SUCCESS);
+    ASSERT_EQ(db->Add(new_key, "new-value", false), MBError::SUCCESS);
+
+    data.Clear();
+    EXPECT_EQ(cached_reader.Find(old_key, data), MBError::NOT_EXIST);
+    data.Clear();
+    ASSERT_EQ(cached_reader.Find(new_key, data), MBError::SUCCESS);
+    EXPECT_EQ(std::string(reinterpret_cast<const char*>(data.buff), data.data_len),
+        "new-value");
 }
 
 } // namespace

--- a/src/unittest/prefix_cache_test.cpp
+++ b/src/unittest/prefix_cache_test.cpp
@@ -14,6 +14,29 @@
 
 using namespace mabain;
 
+namespace mabain {
+
+class PrefixCacheTestPeer {
+public:
+    static int CopyAfterOverwrite(PrefixCache& cache, const uint8_t* key,
+        const PrefixCacheEntry& replacement, PrefixCacheEntry& out)
+    {
+        uint16_t p2 = static_cast<uint16_t>(static_cast<uint16_t>(key[0])
+            | (static_cast<uint16_t>(key[1]) << 8));
+        PrefixCacheEntry& slot = cache.tab2[static_cast<size_t>(p2) & cache.mask2];
+        uint32_t before = PrefixCache::LoadEntryCounterForTest(slot);
+
+        // Force a complete overwrite between the reader's pre-copy snapshot
+        // and its post-copy validation.
+        cache.PutAtDepth(key, 2, replacement);
+        return PrefixCache::CopyStableEntryForTest(slot, before, out)
+            ? 2
+            : PrefixCache::UNSTABLE;
+    }
+};
+
+} // namespace mabain
+
 namespace {
 
 #define MB_DIR "/var/tmp/mabain_test/"
@@ -146,6 +169,42 @@ TEST_F(PrefixCacheTest, SeedFromCache_GetDepth)
     PrefixCacheEntry e4 {};
     int n4 = pc->GetDepth(reinterpret_cast<const uint8_t*>("x"), 1, e4);
     EXPECT_EQ(n4, 0);
+}
+
+TEST_F(PrefixCacheTest, OverwriteBetweenCounterChecksIsRejected)
+{
+    Dict* dict = db->GetDictPtr();
+    ASSERT_NE(dict, nullptr);
+    PrefixCache* pc = dict->ActivePrefixCache();
+    ASSERT_NE(pc, nullptr);
+
+    const uint8_t key[] = { 'q', 'r' };
+    PrefixCacheEntry old_entry {};
+    old_entry.edge_offset = 0x1111111111111111ULL;
+    memset(old_entry.edge_buff, 0x11, sizeof(old_entry.edge_buff));
+    old_entry.edge_skip = 1;
+    old_entry.lf_counter = 1;
+    pc->PutAtDepth(key, 2, old_entry);
+
+    PrefixCacheEntry new_entry {};
+    new_entry.edge_offset = 0x2222222222222222ULL;
+    memset(new_entry.edge_buff, 0x22, sizeof(new_entry.edge_buff));
+    new_entry.edge_skip = 2;
+    new_entry.lf_counter = 2;
+
+    PrefixCacheEntry rejected {};
+    EXPECT_EQ(PrefixCacheTestPeer::CopyAfterOverwrite(*pc, key, new_entry,
+                  rejected),
+        PrefixCache::UNSTABLE);
+
+    PrefixCacheEntry stable {};
+    ASSERT_EQ(pc->GetDepth(key, 2, stable), 2);
+    EXPECT_EQ(stable.edge_offset, new_entry.edge_offset);
+    EXPECT_EQ(memcmp(stable.edge_buff, new_entry.edge_buff,
+                  sizeof(stable.edge_buff)),
+        0);
+    EXPECT_EQ(stable.edge_skip, new_entry.edge_skip);
+    EXPECT_EQ(stable.lf_counter, 3u); // old and new origin bits are preserved
 }
 
 } // namespace

--- a/src/unittest/resource_pool_test.cpp
+++ b/src/unittest/resource_pool_test.cpp
@@ -1,0 +1,79 @@
+/**
+ * Copyright (C) 2026 Cisco Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License, version 2,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <atomic>
+#include <cstdint>
+#include <string>
+#include <thread>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+#include "../error.h"
+#include "../resource_pool.h"
+
+using namespace mabain;
+
+TEST(ResourcePoolTest, CheckExistenceIsStableDuringConcurrentMutation)
+{
+    ResourcePool& pool = ResourcePool::getInstance();
+    pool.RemoveAll();
+
+    const std::string stable_path = "resource-pool-stable-entry";
+    ASSERT_EQ(pool.AddResourceByPath(stable_path, nullptr), MBError::SUCCESS);
+
+    std::atomic<bool> start(false);
+    std::atomic<bool> done(false);
+    std::atomic<bool> missing(false);
+    std::atomic<uint32_t> checks(0);
+
+    std::thread reader([&]() {
+        while (!start.load(std::memory_order_acquire))
+            std::this_thread::yield();
+
+        do {
+            if (!pool.CheckExistence(stable_path))
+                missing.store(true, std::memory_order_relaxed);
+            checks.fetch_add(1, std::memory_order_relaxed);
+        } while (!done.load(std::memory_order_acquire));
+    });
+
+    std::thread mutator([&]() {
+        std::vector<std::string> paths;
+        paths.reserve(5000);
+        start.store(true, std::memory_order_release);
+
+        for (int i = 0; i < 5000; ++i) {
+            paths.push_back("resource-pool-churn-" + std::to_string(i));
+            pool.AddResourceByPath(paths.back(), nullptr);
+        }
+        for (const std::string& path : paths)
+            pool.RemoveResourceByPath(path);
+
+        done.store(true, std::memory_order_release);
+    });
+
+    reader.join();
+    mutator.join();
+
+    EXPECT_GT(checks.load(std::memory_order_relaxed), 0U);
+    EXPECT_FALSE(missing.load(std::memory_order_relaxed));
+    EXPECT_TRUE(pool.CheckExistence(stable_path));
+
+    pool.RemoveResourceByPath(stable_path);
+    EXPECT_FALSE(pool.CheckExistence(stable_path));
+    pool.RemoveAll();
+}

--- a/src/unittest/rollable_file_test.cpp
+++ b/src/unittest/rollable_file_test.cpp
@@ -16,6 +16,7 @@
 
 // @author Changxue Deng <chadeng@cisco.com>
 
+#include <memory>
 #include <string>
 
 #include <gtest/gtest.h>
@@ -245,6 +246,78 @@ TEST_F(RollableFileTest, JemallocPreAllocSetsCursor_test)
 
     void* base_ptr = rfile->PreAlloc(4096);
     ASSERT_NE(base_ptr, nullptr);
+    EXPECT_EQ(rfile->GetJemallocAllocSize(), 4096u);
+}
+
+TEST_F(RollableFileTest, JemallocReaderCloseDoesNotDestroyWriterArena_test)
+{
+    const std::string path = std::string(ROLLABLE_FILE_TEST_DIR)
+        + "/_mabain_jem_writer_first_i";
+    rfile = new RollableFile(path, JEMALLOC_TEST_BLOCK_SIZE,
+        JEMALLOC_TEST_MEMCAP,
+        CONSTS::ACCESS_MODE_WRITER | CONSTS::OPTION_JEMALLOC, 4);
+    ASSERT_NE(rfile, nullptr);
+    ASSERT_NE(rfile->PreAlloc(64), nullptr);
+
+    std::unique_ptr<RollableFile> reader(new RollableFile(path,
+        JEMALLOC_TEST_BLOCK_SIZE, JEMALLOC_TEST_MEMCAP,
+        CONSTS::ACCESS_MODE_READER | CONSTS::OPTION_JEMALLOC, 4));
+    uint8_t value = 0;
+    ASSERT_EQ(reader->MemRead(&value, sizeof(value), 0), sizeof(value));
+    reader.reset();
+
+    size_t offset = 0;
+    EXPECT_NE(rfile->Malloc(128, offset), nullptr);
+    EXPECT_GE(offset, 64u);
+}
+
+TEST_F(RollableFileTest, JemallocWriterOwnsArenaWhenReaderOpenedFirst_test)
+{
+    const std::string path = std::string(ROLLABLE_FILE_TEST_DIR)
+        + "/_mabain_jem_reader_first_i";
+    {
+        RollableFile creator(path, JEMALLOC_TEST_BLOCK_SIZE,
+            JEMALLOC_TEST_MEMCAP, CONSTS::ACCESS_MODE_WRITER, 4);
+        size_t offset = 0;
+        uint8_t* ptr = nullptr;
+        ASSERT_EQ(creator.Reserve(offset, 1, ptr), MBError::SUCCESS);
+    }
+    ResourcePool::getInstance().RemoveAll();
+
+    std::unique_ptr<RollableFile> reader(new RollableFile(path,
+        JEMALLOC_TEST_BLOCK_SIZE, JEMALLOC_TEST_MEMCAP,
+        CONSTS::ACCESS_MODE_READER | CONSTS::OPTION_JEMALLOC, 4));
+    uint8_t value = 0;
+    ASSERT_EQ(reader->MemRead(&value, sizeof(value), 0), sizeof(value));
+
+    rfile = new RollableFile(path, JEMALLOC_TEST_BLOCK_SIZE,
+        JEMALLOC_TEST_MEMCAP,
+        CONSTS::ACCESS_MODE_WRITER | CONSTS::OPTION_JEMALLOC, 4);
+    ASSERT_NE(rfile->PreAlloc(64), nullptr);
+    reader.reset();
+
+    size_t offset = 0;
+    EXPECT_NE(rfile->Malloc(128, offset), nullptr);
+    EXPECT_GE(offset, 64u);
+}
+
+TEST_F(RollableFileTest, JemallocReaderCannotRewindWriterCursor_test)
+{
+    const std::string path = std::string(ROLLABLE_FILE_TEST_DIR)
+        + "/_mabain_jem_reader_cursor_i";
+    rfile = new RollableFile(path, JEMALLOC_TEST_BLOCK_SIZE,
+        JEMALLOC_TEST_MEMCAP,
+        CONSTS::ACCESS_MODE_WRITER | CONSTS::OPTION_JEMALLOC, 4);
+    ASSERT_NE(rfile, nullptr);
+    ASSERT_NE(rfile->PreAlloc(4096), nullptr);
+
+    RollableFile reader(path, JEMALLOC_TEST_BLOCK_SIZE,
+        JEMALLOC_TEST_MEMCAP,
+        CONSTS::ACCESS_MODE_READER | CONSTS::OPTION_JEMALLOC, 4);
+    uint8_t value = 0;
+    ASSERT_EQ(reader.MemRead(&value, sizeof(value), 0), sizeof(value));
+
+    EXPECT_EQ(reader.PreAlloc(128), nullptr);
     EXPECT_EQ(rfile->GetJemallocAllocSize(), 4096u);
 }
 

--- a/src/util/prefix_cache.cpp
+++ b/src/util/prefix_cache.cpp
@@ -42,7 +42,8 @@ static inline size_t cap3_from_capacity(size_t capacity)
 // Construct a prefix cache backed by an embedded mapping in _mabain_d.
 //
 // Embedded Region Layout (in block 0 of _mabain_d):
-//   PCShmHeader | tag2 | tab2 | tag3 | tab3 | valid4 | tag4 | tab4
+//   PCShmHeader | root_epoch | prefix2_epoch |
+//   tag2 | tab2 | tag3 | tab3 | valid4 | tag4 | tab4
 // where:
 //   - PCShmHeader carries magic/version and fixed capacities/masks for tables.
 //   - tag2/tag3 hold (prefix+1) to distinguish empty from p == 0.
@@ -126,14 +127,24 @@ struct PCShmHeader {
     uint32_t mask2;
     uint32_t mask3;
     uint32_t mask4;
+    uint32_t global_epoch;
+    // Keep the following PrefixCacheEntry array 8-byte aligned.
+    uint32_t reserved2;
 };
+
+static_assert(sizeof(PCShmHeader) == 40,
+    "Unexpected shared prefix-cache header layout");
+static_assert(sizeof(PCShmHeader) % alignof(PrefixCacheEntry) == 0,
+    "Shared prefix-cache tables must remain naturally aligned");
 
 // Create or open the shared-memory file and map the cache arrays.
 // Initializes tags/valids on first creation; otherwise issues MADV_WILLNEED.
 bool PrefixCache::map_shared(const std::string& path)
 {
     const uint32_t MAGIC = 0x50434632; // 'PCF2'
-    const uint16_t VER = 2; // bump for 4-byte table layout
+    const uint16_t VER = 3; // folded indexes and hierarchical invalidation
+    size_t er = sizeof(uint32_t) * ROOT_EPOCH_COUNT;
+    size_t e2 = sizeof(uint32_t) * PREFIX2_EPOCH_COUNT;
     size_t t2 = sizeof(PrefixCacheEntry) * (cap2 ? cap2 : 1);
     size_t g2 = sizeof(uint32_t) * (cap2 ? cap2 : 1);
     size_t t3 = sizeof(PrefixCacheEntry) * (cap3 ? cap3 : 1);
@@ -141,7 +152,8 @@ bool PrefixCache::map_shared(const std::string& path)
     size_t t4 = sizeof(PrefixCacheEntry) * (cap4 ? cap4 : 1);
     size_t g4 = sizeof(uint32_t) * (cap4 ? cap4 : 1); // tag4
     size_t v4 = sizeof(uint32_t) * (cap4 ? cap4 : 1); // valid4
-    size_t need = sizeof(PCShmHeader) + g2 + t2 + g3 + t3 + v4 + g4 + t4;
+    size_t need = sizeof(PCShmHeader) + er + e2
+        + g2 + t2 + g3 + t3 + v4 + g4 + t4;
 
     int fd = ::open(path.c_str(), O_CREAT | O_RDWR, 0666);
     if (fd < 0)
@@ -182,10 +194,17 @@ bool PrefixCache::map_shared(const std::string& path)
         hdr->mask2 = static_cast<uint32_t>(mask2);
         hdr->mask3 = static_cast<uint32_t>(mask3);
         hdr->mask4 = static_cast<uint32_t>(mask4);
+        hdr->global_epoch = 0;
+        hdr->reserved2 = 0;
         init = true;
     }
 
     uint8_t* p = reinterpret_cast<uint8_t*>(base) + sizeof(PCShmHeader);
+    global_epoch = &hdr->global_epoch;
+    root_epoch = reinterpret_cast<uint32_t*>(p);
+    p += er;
+    prefix2_epoch = reinterpret_cast<uint32_t*>(p);
+    p += e2;
     tag2 = reinterpret_cast<std::atomic<uint32_t>*>(p);
     p += sizeof(uint32_t) * (cap2 ? cap2 : 1);
     tab2 = reinterpret_cast<PrefixCacheEntry*>(p);
@@ -201,6 +220,11 @@ bool PrefixCache::map_shared(const std::string& path)
     tab4 = (cap4 ? reinterpret_cast<PrefixCacheEntry*>(p) : nullptr);
 
     if (init) {
+        __atomic_store_n(global_epoch, 0u, __ATOMIC_RELAXED);
+        for (size_t i = 0; i < ROOT_EPOCH_COUNT; ++i)
+            __atomic_store_n(&root_epoch[i], 0u, __ATOMIC_RELAXED);
+        for (size_t i = 0; i < PREFIX2_EPOCH_COUNT; ++i)
+            __atomic_store_n(&prefix2_epoch[i], 0u, __ATOMIC_RELAXED);
         size_t c2 = (cap2 ? cap2 : 1);
         for (size_t i = 0; i < c2; ++i)
             tag2[i].store(0u, std::memory_order_relaxed);
@@ -254,7 +278,9 @@ bool PrefixCache::map_embedded(const std::string& mbdir)
 
     // Recreate the same header and tables layout offsets as map_shared, but relative to base+delta
     const uint32_t MAGIC = 0x50434632; // 'PCF2'
-    const uint16_t VER = 2;
+    const uint16_t VER = 3; // folded indexes and hierarchical invalidation
+    size_t er = sizeof(uint32_t) * ROOT_EPOCH_COUNT;
+    size_t e2 = sizeof(uint32_t) * PREFIX2_EPOCH_COUNT;
     size_t t2 = sizeof(PrefixCacheEntry) * (cap2 ? cap2 : 1);
     size_t g2 = sizeof(uint32_t) * (cap2 ? cap2 : 1);
     size_t t3 = sizeof(PrefixCacheEntry) * (cap3 ? cap3 : 1);
@@ -262,7 +288,8 @@ bool PrefixCache::map_embedded(const std::string& mbdir)
     size_t t4 = sizeof(PrefixCacheEntry) * (cap4 ? cap4 : 1);
     size_t g4 = sizeof(uint32_t) * (cap4 ? cap4 : 1); // tag4
     size_t v4 = sizeof(uint32_t) * (cap4 ? cap4 : 1); // valid4
-    size_t need = sizeof(PCShmHeader) + g2 + t2 + g3 + t3 + v4 + g4 + t4;
+    size_t need = sizeof(PCShmHeader) + er + e2
+        + g2 + t2 + g3 + t3 + v4 + g4 + t4;
     if (need != hdr_->pfxcache_size) {
         // Capacity mismatch vs header; clear mapped region and try to proceed if space allows
         // to keep running. Readers/writers can still function without cache.
@@ -285,8 +312,15 @@ bool PrefixCache::map_embedded(const std::string& mbdir)
         hdr->mask2 = static_cast<uint32_t>(mask2);
         hdr->mask3 = static_cast<uint32_t>(mask3);
         hdr->mask4 = static_cast<uint32_t>(mask4);
+        hdr->global_epoch = 0;
+        hdr->reserved2 = 0;
     }
     uint8_t* p = reinterpret_cast<uint8_t*>(hdr) + sizeof(PCShmHeader);
+    global_epoch = &hdr->global_epoch;
+    root_epoch = reinterpret_cast<uint32_t*>(p);
+    p += er;
+    prefix2_epoch = reinterpret_cast<uint32_t*>(p);
+    p += e2;
     tag2 = reinterpret_cast<std::atomic<uint32_t>*>(p);
     p += sizeof(uint32_t) * (cap2 ? cap2 : 1);
     tab2 = reinterpret_cast<PrefixCacheEntry*>(p);
@@ -302,6 +336,11 @@ bool PrefixCache::map_embedded(const std::string& mbdir)
     tab4 = (cap4 ? reinterpret_cast<PrefixCacheEntry*>(p) : nullptr);
 
     if (init) {
+        __atomic_store_n(global_epoch, 0u, __ATOMIC_RELAXED);
+        for (size_t i = 0; i < ROOT_EPOCH_COUNT; ++i)
+            __atomic_store_n(&root_epoch[i], 0u, __ATOMIC_RELAXED);
+        for (size_t i = 0; i < PREFIX2_EPOCH_COUNT; ++i)
+            __atomic_store_n(&prefix2_epoch[i], 0u, __ATOMIC_RELAXED);
         size_t c2 = (cap2 ? cap2 : 1);
         for (size_t i = 0; i < c2; ++i) tag2[i].store(0u, std::memory_order_relaxed);
         if (cap3) for (size_t i = 0; i < cap3; ++i) tag3[i].store(0u, std::memory_order_relaxed);
@@ -364,6 +403,14 @@ constexpr uint32_t PFX_ORIGIN_MASK = 0x3u;
 constexpr uint32_t PFX_COUNTER_STEP = 0x4u;
 constexpr uint32_t PFX_COUNTER_MASK = 0x7FFFFFFCu;
 constexpr uint32_t PFX_UPDATE_ACTIVE = 0x80000000u;
+
+// Fold the upper prefix bytes into the low table-index bits. Unlike a
+// multiply-heavy avalanche hash, this leaves 16-bit integer keys unchanged
+// while distributing fixed-leading-byte string prefixes across sparse tables.
+inline uint32_t FoldPrefix(uint32_t value)
+{
+    return value ^ (value >> 16);
+}
 
 inline uint32_t LoadEntryCounter(const PrefixCacheEntry& entry)
 {
@@ -432,6 +479,42 @@ inline bool CopyStableEntry(const PrefixCacheEntry& src, uint32_t before,
 
 } // namespace
 
+uint32_t PrefixCache::CurrentEpoch(const uint8_t* key, int len) const
+{
+    if (key == nullptr || len < 2 || global_epoch == nullptr
+        || root_epoch == nullptr || prefix2_epoch == nullptr)
+        return 0;
+
+    uint16_t p2;
+    if (!build2(key, len, p2))
+        return 0;
+
+    // Counters only increase. Their modulo-2^32 sum changes whenever any
+    // applicable invalidation scope advances, without enlarging cache entries.
+    return __atomic_load_n(global_epoch, __ATOMIC_ACQUIRE)
+        + __atomic_load_n(&root_epoch[key[0]], __ATOMIC_ACQUIRE)
+        + __atomic_load_n(&prefix2_epoch[p2], __ATOMIC_ACQUIRE);
+}
+
+void PrefixCache::InvalidatePrefix2(const uint8_t* key, int len)
+{
+    uint16_t p2;
+    if (prefix2_epoch != nullptr && build2(key, len, p2))
+        (void)__atomic_add_fetch(&prefix2_epoch[p2], 1u, __ATOMIC_ACQ_REL);
+}
+
+void PrefixCache::InvalidateRoot(uint8_t first_byte)
+{
+    if (root_epoch != nullptr)
+        (void)__atomic_add_fetch(&root_epoch[first_byte], 1u, __ATOMIC_ACQ_REL);
+}
+
+void PrefixCache::InvalidateAll()
+{
+    if (global_epoch != nullptr)
+        (void)__atomic_add_fetch(global_epoch, 1u, __ATOMIC_ACQ_REL);
+}
+
 uint32_t PrefixCache::LoadEntryCounterForTest(const PrefixCacheEntry& entry)
 {
     return LoadEntryCounter(entry);
@@ -451,17 +534,19 @@ int PrefixCache::GetDepth(const uint8_t* key, int len, PrefixCacheEntry& out) co
     if (cap4 > 0 && key != nullptr && len >= 4) {
         uint32_t p4 = static_cast<uint32_t>(static_cast<uint32_t>(key[0]) | (static_cast<uint32_t>(key[1]) << 8)
             | (static_cast<uint32_t>(key[2]) << 16) | (static_cast<uint32_t>(key[3]) << 24));
-        size_t idx4 = static_cast<size_t>(p4) & mask4;
-        uint32_t before = LoadEntryCounter(tab4[idx4]);
-        if (!EntryUpdateActive(before)) {
-            uint32_t v = valid4[idx4].load(std::memory_order_acquire);
-            if (v) {
-                uint32_t t4 = tag4[idx4].load(std::memory_order_acquire);
-                if (t4 == p4) {
-                    if (!CopyStableEntry(tab4[idx4], before, out))
-                        return UNSTABLE;
-                    return 4;
-                }
+        size_t idx4 = static_cast<size_t>(FoldPrefix(p4)) & mask4;
+        uint32_t valid = valid4[idx4].load(std::memory_order_acquire);
+        if (valid && tag4[idx4].load(std::memory_order_acquire) == p4) {
+            uint32_t before = LoadEntryCounter(tab4[idx4]);
+            if (!EntryUpdateActive(before)) {
+                if (!CopyStableEntry(tab4[idx4], before, out))
+                    return UNSTABLE;
+                if (!valid4[idx4].load(std::memory_order_acquire)
+                    || tag4[idx4].load(std::memory_order_acquire) != p4)
+                    return UNSTABLE;
+                if (out.cache_epoch != CurrentEpoch(key, len))
+                    return 0;
+                return 4;
             }
         }
         // fall through to 3/2 below on miss or alias
@@ -470,25 +555,34 @@ int PrefixCache::GetDepth(const uint8_t* key, int len, PrefixCacheEntry& out) co
         // Little-endian 3-byte build
         uint32_t p3 = static_cast<uint32_t>(static_cast<uint32_t>(key[0]) | (static_cast<uint32_t>(key[1]) << 8)
             | (static_cast<uint32_t>(key[2]) << 16));
-        size_t idx3 = static_cast<size_t>(p3) & mask3;
-        uint32_t before3 = LoadEntryCounter(tab3[idx3]);
-        if (!EntryUpdateActive(before3)) {
-            uint32_t t3 = tag3[idx3].load(std::memory_order_acquire);
-            if (t3 == (p3 + 1)) {
+        size_t idx3 = static_cast<size_t>(FoldPrefix(p3)) & mask3;
+        if (tag3[idx3].load(std::memory_order_acquire) == (p3 + 1)) {
+            uint32_t before3 = LoadEntryCounter(tab3[idx3]);
+            if (!EntryUpdateActive(before3)) {
                 if (!CopyStableEntry(tab3[idx3], before3, out))
                     return UNSTABLE;
+                if (tag3[idx3].load(std::memory_order_acquire) != (p3 + 1))
+                    return UNSTABLE;
+                if (out.cache_epoch != CurrentEpoch(key, len))
+                    return 0;
                 return 3;
             }
         }
         // Fall back to 2-byte table using lower 2 bytes of p3 (LE)
         uint16_t p2 = static_cast<uint16_t>(p3 & 0xFFFFu);
         size_t idx2 = static_cast<size_t>(p2) & mask2;
-        uint32_t before2 = LoadEntryCounter(tab2[idx2]);
-        if (!EntryUpdateActive(before2)) {
-            uint32_t t2 = tag2[idx2].load(std::memory_order_acquire);
-            if ((full2 && t2) || (!full2 && t2 == (static_cast<uint32_t>(p2) + 1))) {
+        uint32_t tag = tag2[idx2].load(std::memory_order_acquire);
+        if ((full2 && tag) || (!full2 && tag == (static_cast<uint32_t>(p2) + 1))) {
+            uint32_t before2 = LoadEntryCounter(tab2[idx2]);
+            if (!EntryUpdateActive(before2)) {
                 if (!CopyStableEntry(tab2[idx2], before2, out))
                     return UNSTABLE;
+                uint32_t after_tag = tag2[idx2].load(std::memory_order_acquire);
+                if (!((full2 && after_tag)
+                        || (!full2 && after_tag == (static_cast<uint32_t>(p2) + 1))))
+                    return UNSTABLE;
+                if (out.cache_epoch != CurrentEpoch(key, len))
+                    return 0;
                 return 2;
             }
         }
@@ -498,12 +592,18 @@ int PrefixCache::GetDepth(const uint8_t* key, int len, PrefixCacheEntry& out) co
         // Little-endian 2-byte build
         uint16_t p2 = static_cast<uint16_t>(static_cast<uint16_t>(key[0]) | (static_cast<uint16_t>(key[1]) << 8));
         size_t idx2 = static_cast<size_t>(p2) & mask2;
-        uint32_t before = LoadEntryCounter(tab2[idx2]);
-        if (!EntryUpdateActive(before)) {
-            uint32_t t2 = tag2[idx2].load(std::memory_order_acquire);
-            if ((full2 && t2) || (!full2 && t2 == (static_cast<uint32_t>(p2) + 1))) {
+        uint32_t tag = tag2[idx2].load(std::memory_order_acquire);
+        if ((full2 && tag) || (!full2 && tag == (static_cast<uint32_t>(p2) + 1))) {
+            uint32_t before = LoadEntryCounter(tab2[idx2]);
+            if (!EntryUpdateActive(before)) {
                 if (!CopyStableEntry(tab2[idx2], before, out))
                     return UNSTABLE;
+                uint32_t after_tag = tag2[idx2].load(std::memory_order_acquire);
+                if (!((full2 && after_tag)
+                        || (!full2 && after_tag == (static_cast<uint32_t>(p2) + 1))))
+                    return UNSTABLE;
+                if (out.cache_epoch != CurrentEpoch(key, len))
+                    return 0;
                 return 2;
             }
         }
@@ -515,15 +615,18 @@ int PrefixCache::GetDepth(const uint8_t* key, int len, PrefixCacheEntry& out) co
 // Uses release-ordering on tag/valid to publish after the entry body is written.
 void PrefixCache::Put(const uint8_t* key, int len, const PrefixCacheEntry& in)
 {
+    PrefixCacheEntry seeded = in;
+    seeded.cache_epoch = CurrentEpoch(key, len);
+
     // Insert into 4-byte table if we have at least 4 bytes
     uint32_t p4;
     if (cap4 > 0 && build4(key, len, p4)) {
-        size_t idx4 = static_cast<size_t>(p4) & mask4;
-        uint32_t stable_counter = BeginEntryUpdate(tab4[idx4], in.lf_counter,
+        size_t idx4 = static_cast<size_t>(FoldPrefix(p4)) & mask4;
+        uint32_t stable_counter = BeginEntryUpdate(tab4[idx4], seeded.lf_counter,
             false);
         // Clear valid first to prevent readers from observing partial update
         valid4[idx4].store(0, std::memory_order_release);
-        CopyEntryBody(tab4[idx4], in);
+        CopyEntryBody(tab4[idx4], seeded);
         tag4[idx4].store(p4, std::memory_order_release);
         valid4[idx4].store(1, std::memory_order_release);
         FinishEntryUpdate(tab4[idx4], stable_counter);
@@ -532,13 +635,13 @@ void PrefixCache::Put(const uint8_t* key, int len, const PrefixCacheEntry& in)
     // Insert into 3-byte table if we have at least 3 bytes
     uint32_t p3;
     if (cap3 > 0 && build3(key, len, p3)) {
-        size_t idx3 = static_cast<size_t>(p3) & mask3;
+        size_t idx3 = static_cast<size_t>(FoldPrefix(p3)) & mask3;
         uint32_t old_tag = tag3[idx3].load(std::memory_order_relaxed);
-        uint32_t stable_counter = BeginEntryUpdate(tab3[idx3], in.lf_counter,
+        uint32_t stable_counter = BeginEntryUpdate(tab3[idx3], seeded.lf_counter,
             old_tag != 0);
         // Clear tag to prevent readers from observing partial update
         tag3[idx3].store(0, std::memory_order_release);
-        CopyEntryBody(tab3[idx3], in);
+        CopyEntryBody(tab3[idx3], seeded);
         tag3[idx3].store(p3 + 1, std::memory_order_release); // publish
         FinishEntryUpdate(tab3[idx3], stable_counter);
         ++put_count;
@@ -548,10 +651,10 @@ void PrefixCache::Put(const uint8_t* key, int len, const PrefixCacheEntry& in)
     if (build2(key, len, p2)) {
         size_t idx2 = static_cast<size_t>(p2) & mask2;
         uint32_t old_tag = tag2[idx2].load(std::memory_order_relaxed);
-        uint32_t stable_counter = BeginEntryUpdate(tab2[idx2], in.lf_counter,
+        uint32_t stable_counter = BeginEntryUpdate(tab2[idx2], seeded.lf_counter,
             old_tag != 0);
         tag2[idx2].store(0, std::memory_order_release);
-        CopyEntryBody(tab2[idx2], in);
+        CopyEntryBody(tab2[idx2], seeded);
         tag2[idx2].store(static_cast<uint32_t>(p2) + 1, std::memory_order_release);
         FinishEntryUpdate(tab2[idx2], stable_counter);
         ++put_count;
@@ -562,14 +665,17 @@ void PrefixCache::Put(const uint8_t* key, int len, const PrefixCacheEntry& in)
 // Used by writer to seed canonical boundaries and mid-edge seeds.
 void PrefixCache::PutAtDepth(const uint8_t* key, int depth, const PrefixCacheEntry& in)
 {
+    PrefixCacheEntry seeded = in;
+    seeded.cache_epoch = CurrentEpoch(key, depth);
+
     if (depth == 4 && cap4 > 0) {
         uint32_t p4;
         if (build4(key, 4, p4)) {
-            size_t idx4 = static_cast<size_t>(p4) & mask4;
-            uint32_t stable_counter = BeginEntryUpdate(tab4[idx4], in.lf_counter,
+            size_t idx4 = static_cast<size_t>(FoldPrefix(p4)) & mask4;
+            uint32_t stable_counter = BeginEntryUpdate(tab4[idx4], seeded.lf_counter,
                 false);
             valid4[idx4].store(0, std::memory_order_release);
-            CopyEntryBody(tab4[idx4], in);
+            CopyEntryBody(tab4[idx4], seeded);
             tag4[idx4].store(p4, std::memory_order_release);
             valid4[idx4].store(1, std::memory_order_release);
             FinishEntryUpdate(tab4[idx4], stable_counter);
@@ -580,12 +686,12 @@ void PrefixCache::PutAtDepth(const uint8_t* key, int depth, const PrefixCacheEnt
     if (depth == 3 && cap3 > 0) {
         uint32_t p3;
         if (build3(key, 3, p3)) {
-            size_t idx3 = static_cast<size_t>(p3) & mask3;
+            size_t idx3 = static_cast<size_t>(FoldPrefix(p3)) & mask3;
             uint32_t old_tag = tag3[idx3].load(std::memory_order_relaxed);
-            uint32_t stable_counter = BeginEntryUpdate(tab3[idx3], in.lf_counter,
+            uint32_t stable_counter = BeginEntryUpdate(tab3[idx3], seeded.lf_counter,
                 old_tag != 0);
             tag3[idx3].store(0, std::memory_order_release);
-            CopyEntryBody(tab3[idx3], in);
+            CopyEntryBody(tab3[idx3], seeded);
             tag3[idx3].store(p3 + 1, std::memory_order_release);
             FinishEntryUpdate(tab3[idx3], stable_counter);
             ++put_count;
@@ -597,10 +703,10 @@ void PrefixCache::PutAtDepth(const uint8_t* key, int depth, const PrefixCacheEnt
         if (build2(key, 2, p2)) {
             size_t idx2 = static_cast<size_t>(p2) & mask2;
             uint32_t old_tag = tag2[idx2].load(std::memory_order_relaxed);
-            uint32_t stable_counter = BeginEntryUpdate(tab2[idx2], in.lf_counter,
+            uint32_t stable_counter = BeginEntryUpdate(tab2[idx2], seeded.lf_counter,
                 old_tag != 0);
             tag2[idx2].store(0, std::memory_order_release);
-            CopyEntryBody(tab2[idx2], in);
+            CopyEntryBody(tab2[idx2], seeded);
             tag2[idx2].store(static_cast<uint32_t>(p2) + 1, std::memory_order_release);
             FinishEntryUpdate(tab2[idx2], stable_counter);
             ++put_count;

--- a/src/util/prefix_cache.cpp
+++ b/src/util/prefix_cache.cpp
@@ -49,7 +49,9 @@ static inline size_t cap3_from_capacity(size_t capacity)
 //   - 4-byte table uses a separate valid[] bitmap and exact tag4 values to avoid
 //     overflow; publish protocol clears valid, writes body+tag, then sets valid.
 //
-// Publication/reads use release/acquire on the atomic tag/valid arrays.
+// Publication/reads use release/acquire on the atomic tag/valid arrays and a
+// per-entry optimistic counter so readers can reject an entry changed while
+// its non-atomic body was being copied.
 PrefixCache::PrefixCache(const std::string& mbdir, const IndexHeader* hdr, size_t capacity)
     : cap2(0)
     , cap3(0)
@@ -356,20 +358,110 @@ inline bool PrefixCache::build4(const uint8_t* key, int len, uint32_t& p4) const
     return true;
 }
 
+namespace {
+
+constexpr uint32_t PFX_ORIGIN_MASK = 0x3u;
+constexpr uint32_t PFX_COUNTER_STEP = 0x4u;
+constexpr uint32_t PFX_COUNTER_MASK = 0x7FFFFFFCu;
+constexpr uint32_t PFX_UPDATE_ACTIVE = 0x80000000u;
+
+inline uint32_t LoadEntryCounter(const PrefixCacheEntry& entry)
+{
+    return __atomic_load_n(&entry.lf_counter, __ATOMIC_ACQUIRE);
+}
+
+inline bool EntryUpdateActive(uint32_t counter)
+{
+    return (counter & PFX_UPDATE_ACTIVE) != 0;
+}
+
+inline uint32_t BeginEntryUpdate(PrefixCacheEntry& entry, uint32_t origin_flags,
+    bool preserve_origin)
+{
+    uint32_t old_counter = LoadEntryCounter(entry);
+    if (preserve_origin)
+        origin_flags |= old_counter & PFX_ORIGIN_MASK;
+
+    uint32_t generation = ((old_counter & PFX_COUNTER_MASK) + PFX_COUNTER_STEP)
+        & PFX_COUNTER_MASK;
+    uint32_t stable_counter = generation | (origin_flags & PFX_ORIGIN_MASK);
+
+    // The acquire side of the exchange keeps subsequent body stores after the
+    // active marker; the final release store publishes the completed body.
+    __atomic_exchange_n(&entry.lf_counter, stable_counter | PFX_UPDATE_ACTIVE,
+        __ATOMIC_ACQ_REL);
+    return stable_counter;
+}
+
+inline void FinishEntryUpdate(PrefixCacheEntry& entry, uint32_t stable_counter)
+{
+    __atomic_store_n(&entry.lf_counter, stable_counter, __ATOMIC_RELEASE);
+}
+
+inline void CopyEntryBody(PrefixCacheEntry& dst, const PrefixCacheEntry& src)
+{
+    // `lf_counter` is the final field. Copy the contiguous payload in one
+    // operation while leaving the active generation marker untouched.
+    memcpy(&dst, &src, offsetof(PrefixCacheEntry, lf_counter));
+}
+
+inline bool CopyStableEntry(const PrefixCacheEntry& src, uint32_t before,
+    PrefixCacheEntry& out)
+{
+    // Intentional Mabain optimistic snapshot protocol, matching
+    // LockFree::ReaderLockFreeStart/Stop: copy the mmap-backed payload, then
+    // accept it only if the atomic generation is unchanged and inactive.
+    // This relies on Mabain's validated GCC/Linux x86-64 ordering rather than
+    // providing a general ISO C++ synchronization primitive. A port to another
+    // compiler or architecture must validate both protocols together.
+    // See prefix_cache_snapshot_concurrency_test.cpp.
+    PrefixCacheEntry candidate {};
+    CopyEntryBody(candidate, src);
+
+    // Keep the body copy before the final validation load. This is Mabain's
+    // existing optimistic read pattern: consume the copy only when unchanged.
+    std::atomic_thread_fence(std::memory_order_acquire);
+    uint32_t after = LoadEntryCounter(src);
+    if (before != after || EntryUpdateActive(after))
+        return false;
+
+    candidate.lf_counter = after & PFX_ORIGIN_MASK;
+    out = candidate;
+    return true;
+}
+
+} // namespace
+
+uint32_t PrefixCache::LoadEntryCounterForTest(const PrefixCacheEntry& entry)
+{
+    return LoadEntryCounter(entry);
+}
+
+bool PrefixCache::CopyStableEntryForTest(const PrefixCacheEntry& src,
+    uint32_t before, PrefixCacheEntry& out)
+{
+    return CopyStableEntry(src, before, out);
+}
+
 // Lookup the deepest available cached entry for the given key prefix.
-// Returns 4, 3, 2 for hits at that depth; 0 on miss. Out param receives the cached entry.
+// Returns 4, 3, 2 for stable hits; 0 on miss; UNSTABLE when a matching slot
+// changed while copied. Out receives the entry only after validation succeeds.
 int PrefixCache::GetDepth(const uint8_t* key, int len, PrefixCacheEntry& out) const
 {
     if (cap4 > 0 && key != nullptr && len >= 4) {
         uint32_t p4 = static_cast<uint32_t>(static_cast<uint32_t>(key[0]) | (static_cast<uint32_t>(key[1]) << 8)
             | (static_cast<uint32_t>(key[2]) << 16) | (static_cast<uint32_t>(key[3]) << 24));
         size_t idx4 = static_cast<size_t>(p4) & mask4;
-        uint32_t v = valid4[idx4].load(std::memory_order_acquire);
-        if (v) {
-            uint32_t t4 = tag4[idx4].load(std::memory_order_acquire);
-            if (t4 == p4) {
-                out = tab4[idx4];
-                return 4;
+        uint32_t before = LoadEntryCounter(tab4[idx4]);
+        if (!EntryUpdateActive(before)) {
+            uint32_t v = valid4[idx4].load(std::memory_order_acquire);
+            if (v) {
+                uint32_t t4 = tag4[idx4].load(std::memory_order_acquire);
+                if (t4 == p4) {
+                    if (!CopyStableEntry(tab4[idx4], before, out))
+                        return UNSTABLE;
+                    return 4;
+                }
             }
         }
         // fall through to 3/2 below on miss or alias
@@ -379,18 +471,26 @@ int PrefixCache::GetDepth(const uint8_t* key, int len, PrefixCacheEntry& out) co
         uint32_t p3 = static_cast<uint32_t>(static_cast<uint32_t>(key[0]) | (static_cast<uint32_t>(key[1]) << 8)
             | (static_cast<uint32_t>(key[2]) << 16));
         size_t idx3 = static_cast<size_t>(p3) & mask3;
-        uint32_t t3 = tag3[idx3].load(std::memory_order_acquire);
-        if (t3 == (p3 + 1)) {
-            out = tab3[idx3];
-            return 3;
+        uint32_t before3 = LoadEntryCounter(tab3[idx3]);
+        if (!EntryUpdateActive(before3)) {
+            uint32_t t3 = tag3[idx3].load(std::memory_order_acquire);
+            if (t3 == (p3 + 1)) {
+                if (!CopyStableEntry(tab3[idx3], before3, out))
+                    return UNSTABLE;
+                return 3;
+            }
         }
         // Fall back to 2-byte table using lower 2 bytes of p3 (LE)
         uint16_t p2 = static_cast<uint16_t>(p3 & 0xFFFFu);
         size_t idx2 = static_cast<size_t>(p2) & mask2;
-        uint32_t t2 = tag2[idx2].load(std::memory_order_acquire);
-        if ((full2 && t2) || (!full2 && t2 == (static_cast<uint32_t>(p2) + 1))) {
-            out = tab2[idx2];
-            return 2;
+        uint32_t before2 = LoadEntryCounter(tab2[idx2]);
+        if (!EntryUpdateActive(before2)) {
+            uint32_t t2 = tag2[idx2].load(std::memory_order_acquire);
+            if ((full2 && t2) || (!full2 && t2 == (static_cast<uint32_t>(p2) + 1))) {
+                if (!CopyStableEntry(tab2[idx2], before2, out))
+                    return UNSTABLE;
+                return 2;
+            }
         }
         return 0;
     }
@@ -398,10 +498,14 @@ int PrefixCache::GetDepth(const uint8_t* key, int len, PrefixCacheEntry& out) co
         // Little-endian 2-byte build
         uint16_t p2 = static_cast<uint16_t>(static_cast<uint16_t>(key[0]) | (static_cast<uint16_t>(key[1]) << 8));
         size_t idx2 = static_cast<size_t>(p2) & mask2;
-        uint32_t t2 = tag2[idx2].load(std::memory_order_acquire);
-        if ((full2 && t2) || (!full2 && t2 == (static_cast<uint32_t>(p2) + 1))) {
-            out = tab2[idx2];
-            return 2;
+        uint32_t before = LoadEntryCounter(tab2[idx2]);
+        if (!EntryUpdateActive(before)) {
+            uint32_t t2 = tag2[idx2].load(std::memory_order_acquire);
+            if ((full2 && t2) || (!full2 && t2 == (static_cast<uint32_t>(p2) + 1))) {
+                if (!CopyStableEntry(tab2[idx2], before, out))
+                    return UNSTABLE;
+                return 2;
+            }
         }
     }
     return 0;
@@ -415,12 +519,14 @@ void PrefixCache::Put(const uint8_t* key, int len, const PrefixCacheEntry& in)
     uint32_t p4;
     if (cap4 > 0 && build4(key, len, p4)) {
         size_t idx4 = static_cast<size_t>(p4) & mask4;
+        uint32_t stable_counter = BeginEntryUpdate(tab4[idx4], in.lf_counter,
+            false);
         // Clear valid first to prevent readers from observing partial update
         valid4[idx4].store(0, std::memory_order_release);
-        PrefixCacheEntry e = in;
-        tab4[idx4] = e;
+        CopyEntryBody(tab4[idx4], in);
         tag4[idx4].store(p4, std::memory_order_release);
         valid4[idx4].store(1, std::memory_order_release);
+        FinishEntryUpdate(tab4[idx4], stable_counter);
         ++put_count;
     }
     // Insert into 3-byte table if we have at least 3 bytes
@@ -428,15 +534,13 @@ void PrefixCache::Put(const uint8_t* key, int len, const PrefixCacheEntry& in)
     if (cap3 > 0 && build3(key, len, p3)) {
         size_t idx3 = static_cast<size_t>(p3) & mask3;
         uint32_t old_tag = tag3[idx3].load(std::memory_order_relaxed);
-        PrefixCacheEntry e = in;
-        if (old_tag != 0) {
-            // Preserve prior origin bits on overwrite
-            e.lf_counter |= tab3[idx3].lf_counter;
-        }
+        uint32_t stable_counter = BeginEntryUpdate(tab3[idx3], in.lf_counter,
+            old_tag != 0);
         // Clear tag to prevent readers from observing partial update
         tag3[idx3].store(0, std::memory_order_release);
-        tab3[idx3] = e; // write body
+        CopyEntryBody(tab3[idx3], in);
         tag3[idx3].store(p3 + 1, std::memory_order_release); // publish
+        FinishEntryUpdate(tab3[idx3], stable_counter);
         ++put_count;
     }
     // Also insert into 2-byte table if we have at least 2 bytes
@@ -444,13 +548,12 @@ void PrefixCache::Put(const uint8_t* key, int len, const PrefixCacheEntry& in)
     if (build2(key, len, p2)) {
         size_t idx2 = static_cast<size_t>(p2) & mask2;
         uint32_t old_tag = tag2[idx2].load(std::memory_order_relaxed);
-        PrefixCacheEntry e = in;
-        if (old_tag != 0) {
-            e.lf_counter |= tab2[idx2].lf_counter;
-        }
+        uint32_t stable_counter = BeginEntryUpdate(tab2[idx2], in.lf_counter,
+            old_tag != 0);
         tag2[idx2].store(0, std::memory_order_release);
-        tab2[idx2] = e;
+        CopyEntryBody(tab2[idx2], in);
         tag2[idx2].store(static_cast<uint32_t>(p2) + 1, std::memory_order_release);
+        FinishEntryUpdate(tab2[idx2], stable_counter);
         ++put_count;
     }
 }
@@ -463,11 +566,13 @@ void PrefixCache::PutAtDepth(const uint8_t* key, int depth, const PrefixCacheEnt
         uint32_t p4;
         if (build4(key, 4, p4)) {
             size_t idx4 = static_cast<size_t>(p4) & mask4;
+            uint32_t stable_counter = BeginEntryUpdate(tab4[idx4], in.lf_counter,
+                false);
             valid4[idx4].store(0, std::memory_order_release);
-            PrefixCacheEntry e = in;
-            tab4[idx4] = e;
+            CopyEntryBody(tab4[idx4], in);
             tag4[idx4].store(p4, std::memory_order_release);
             valid4[idx4].store(1, std::memory_order_release);
+            FinishEntryUpdate(tab4[idx4], stable_counter);
             ++put_count;
         }
         return;
@@ -477,12 +582,12 @@ void PrefixCache::PutAtDepth(const uint8_t* key, int depth, const PrefixCacheEnt
         if (build3(key, 3, p3)) {
             size_t idx3 = static_cast<size_t>(p3) & mask3;
             uint32_t old_tag = tag3[idx3].load(std::memory_order_relaxed);
-            PrefixCacheEntry e = in;
-            if (old_tag != 0)
-                e.lf_counter |= tab3[idx3].lf_counter;
+            uint32_t stable_counter = BeginEntryUpdate(tab3[idx3], in.lf_counter,
+                old_tag != 0);
             tag3[idx3].store(0, std::memory_order_release);
-            tab3[idx3] = e;
+            CopyEntryBody(tab3[idx3], in);
             tag3[idx3].store(p3 + 1, std::memory_order_release);
+            FinishEntryUpdate(tab3[idx3], stable_counter);
             ++put_count;
         }
         return;
@@ -492,12 +597,12 @@ void PrefixCache::PutAtDepth(const uint8_t* key, int depth, const PrefixCacheEnt
         if (build2(key, 2, p2)) {
             size_t idx2 = static_cast<size_t>(p2) & mask2;
             uint32_t old_tag = tag2[idx2].load(std::memory_order_relaxed);
-            PrefixCacheEntry e = in;
-            if (old_tag != 0)
-                e.lf_counter |= tab2[idx2].lf_counter;
+            uint32_t stable_counter = BeginEntryUpdate(tab2[idx2], in.lf_counter,
+                old_tag != 0);
             tag2[idx2].store(0, std::memory_order_release);
-            tab2[idx2] = e;
+            CopyEntryBody(tab2[idx2], in);
             tag2[idx2].store(static_cast<uint32_t>(p2) + 1, std::memory_order_release);
+            FinishEntryUpdate(tab2[idx2], stable_counter);
             ++put_count;
         }
         return;

--- a/src/util/prefix_cache.h
+++ b/src/util/prefix_cache.h
@@ -31,14 +31,17 @@ namespace mabain {
 //
 // - 3-byte table (tab3/tag3):
 //   - Capacity is a power-of-two (possibly zero) selected from the requested
-//     capacity remainder. The index uses `p3 & mask3` and the tag stores `p3+1`.
+//     capacity remainder. The index folds the high prefix byte into the low
+//     index bits and the tag stores `p3+1`.
 //   - Because of masking there can be aliasing; the `+1` tag scheme allows us to
 //     safely differentiate empty from a legitimate `p3 == 0` and validate hits.
 //   - This table provides higher specificity than 2-byte, reducing false positives
 //     under aliasing while remaining compact.
 //
 // - 4-byte sparse table (tab4/tag4/valid4):
-//   - Capacity is also a power-of-two and indexing uses `p4 & mask4`.
+//   - Capacity is also a power-of-two. Indexing folds the upper 16 bits into
+//     the lower bits, preserving collision-free indexing for 16-bit integer
+//     values while using all four bytes for common fixed-leading-byte keys.
 //   - We store the exact 32-bit prefix in `tag4` and keep a separate `valid4`
 //     bitmap (0 = empty, 1 = populated). Readers check `valid4[idx] != 0` and
 //     then compare `tag4[idx] == p4` to validate. Writers clear `valid4` first,
@@ -59,6 +62,9 @@ namespace mabain {
 // - The low two `lf_counter` bits are carried over on overwrites to preserve
 //   origin flags when the same slot is reused (e.g., due to aliasing). The
 //   remaining bits are reserved for optimistic update validation.
+// - Each entry snapshots a hierarchical cache epoch. Remove invalidates the
+//   narrowest safe two-byte or first-byte partition in O(1), while RemoveAll
+//   advances the global epoch in O(1). Stale entries become cache misses.
 // - All pointers reference a single shared-memory mapping; there is no
 //   process-local fallback.
 
@@ -68,11 +74,17 @@ struct PrefixCacheEntry {
     // Number of bytes already consumed within the current edge label
     // when this entry is used (1..edge_len). 0 means start-of-edge.
     uint8_t edge_skip;
-    uint8_t reserved_[3];
+    uint8_t reserved_[2];
+    // Sum of global, first-byte, and two-byte invalidation generations when
+    // this entry was published. It occupies existing structure padding.
+    uint32_t cache_epoch;
     // Low two bits record origin. The cache uses the remaining bits as a
     // per-slot generation/active marker for optimistic read validation.
     uint32_t lf_counter;
 };
+
+static_assert(sizeof(PrefixCacheEntry) == 32,
+    "PrefixCacheEntry layout must remain compact");
 
 class PrefixCacheTestPeer;
 
@@ -88,6 +100,10 @@ public:
     // slot changed while it was copied. Callers should retry on UNSTABLE.
     static constexpr int UNSTABLE = -1;
     int GetDepth(const uint8_t* key, int len, PrefixCacheEntry& out) const;
+    // Logically invalidate cache entries without scanning cache tables.
+    void InvalidatePrefix2(const uint8_t* key, int len);
+    void InvalidateRoot(uint8_t first_byte);
+    void InvalidateAll();
     // Report the maximum prefix length this cache can seed from (3 bytes reported for compatibility)
     int PrefixLen() const { return 3; }
     bool IsShared() const { return true; }
@@ -121,6 +137,7 @@ private:
     inline bool build2(const uint8_t* key, int len, uint16_t& p2) const;
     inline bool build3(const uint8_t* key, int len, uint32_t& p3) const;
     inline bool build4(const uint8_t* key, int len, uint32_t& p4) const;
+    uint32_t CurrentEpoch(const uint8_t* key, int len) const;
 
     const size_t cap2;
     const size_t cap3;
@@ -140,6 +157,16 @@ private:
     PrefixCacheEntry* tab4 = nullptr;
     std::atomic<uint32_t>* tag4 = nullptr; // stores exact 32-bit prefix
     std::atomic<uint32_t>* valid4 = nullptr; // 0 = empty, 1 = valid
+
+    // Hierarchical invalidation generations stored in the shared mapping.
+    // `global_epoch` handles RemoveAll, `root_epoch` handles shallow trie
+    // restructuring, and `prefix2_epoch` handles the normal removal case.
+    uint32_t* global_epoch = nullptr;
+    uint32_t* root_epoch = nullptr;
+    uint32_t* prefix2_epoch = nullptr;
+
+    static constexpr size_t ROOT_EPOCH_COUNT = 256;
+    static constexpr size_t PREFIX2_EPOCH_COUNT = 65536;
 
     // Hit/miss counters removed; keep only put_count for write diagnostics
     mutable uint64_t put_count = 0;

--- a/src/util/prefix_cache.h
+++ b/src/util/prefix_cache.h
@@ -51,12 +51,14 @@ namespace mabain {
 //   acquire on reads and release on writes. For 2/3-byte tables, publication is
 //   done by writing `tag=0`, storing the body, then `tag=p+1` (release). For the
 //   4-byte table, publication is `valid=0`, store body, store `tag=p4` (release),
-//   then `valid=1` (release). Reads use acquire loads to validate and then copy
-//   the body directly.
+//   then `valid=1` (release). Each entry's `lf_counter` also carries an update
+//   generation. Readers snapshot it before copying and accept the body only if
+//   the counter is unchanged afterward.
 //
 // Notes
-// - `lf_counter` is carried over on overwrites to preserve origin bits when the
-//   same slot is reused (e.g., due to aliasing).
+// - The low two `lf_counter` bits are carried over on overwrites to preserve
+//   origin flags when the same slot is reused (e.g., due to aliasing). The
+//   remaining bits are reserved for optimistic update validation.
 // - All pointers reference a single shared-memory mapping; there is no
 //   process-local fallback.
 
@@ -67,8 +69,12 @@ struct PrefixCacheEntry {
     // when this entry is used (1..edge_len). 0 means start-of-edge.
     uint8_t edge_skip;
     uint8_t reserved_[3];
+    // Low two bits record origin. The cache uses the remaining bits as a
+    // per-slot generation/active marker for optimistic read validation.
     uint32_t lf_counter;
 };
+
+class PrefixCacheTestPeer;
 
 class PrefixCache {
 public:
@@ -78,6 +84,9 @@ public:
 
     void Put(const uint8_t* key, int len, const PrefixCacheEntry& in);
     void PutAtDepth(const uint8_t* key, int depth, const PrefixCacheEntry& in);
+    // Returns 4/3/2 on a stable hit, 0 on miss, or UNSTABLE when a matching
+    // slot changed while it was copied. Callers should retry on UNSTABLE.
+    static constexpr int UNSTABLE = -1;
     int GetDepth(const uint8_t* key, int len, PrefixCacheEntry& out) const;
     // Report the maximum prefix length this cache can seed from (3 bytes reported for compatibility)
     int PrefixLen() const { return 3; }
@@ -103,6 +112,12 @@ public:
     void ResetStats() { put_count = 0; }
 
 private:
+    friend class PrefixCacheTestPeer;
+
+    static uint32_t LoadEntryCounterForTest(const PrefixCacheEntry& entry);
+    static bool CopyStableEntryForTest(const PrefixCacheEntry& src, uint32_t before,
+        PrefixCacheEntry& out);
+
     inline bool build2(const uint8_t* key, int len, uint16_t& p2) const;
     inline bool build3(const uint8_t* key, int len, uint32_t& p3) const;
     inline bool build4(const uint8_t* key, int len, uint32_t& p4) const;


### PR DESCRIPTION
## Summary

- harden async queue reservation, publication, timeout recovery, bounds checking, and full-queue behavior
- coordinate startup rebuild readers through a shared barrier and safely reclaim stale reader epoch slots
- validate prefix-cache lookup snapshots before using non-atomic cache data
- optimize 3-byte and 4-byte prefix-cache indexing so fixed-leading-byte keys distribute across the cache instead of colliding into a small slot subset
- make `Remove()` and `RemoveAll()` prefix-cache invalidation O(1) with hierarchical shared epochs; stale entries become cache misses rather than requiring a full cache scan
- tighten constructor, logger, resource-pool, and rollable-file error handling
- add focused unit, concurrency, timeout, stress, and prefix-cache removal coverage
- add `src/test/TEST_RUNBOOK.md` covering the tracked unit, standalone, soak, destructive, and performance tests
- ignore generated build/test binaries without ignoring tracked test inputs

## Latest commit

- `12d534e` Optimize prefix cache lookup and invalidation

## Validation

Completed:

- `cmake -S . -B build -DMB_WERROR=ON`
- `cmake --build build --parallel 24`
- `make -C src/unittest clean build`
- `make -C src/test clean all`
- full GoogleTest suite: 154/154 passed
- standalone correctness/concurrency tests: `errno95_db_writer_test`, `mb_header_test`, `shmq_reservation_timeout_test`, `shmq_queue_full_stress_test`, `prefix_cache_snapshot_concurrency_test`, `shared_prefix_cache_concurrency_test`, and `find_lower_bound_concurrency_test`
- all independent jemalloc restart/rebuild modes and the four-reader full-cycle scenario
- memory-management/lower-bound/writer stress tests: `mb_mm_test` (int and SHA-1), `mb_mm_prune_test` (int and SHA-256), `multi_writer_bug_test`, and `mb_bound_test`
- data-driven `jemalloc_test`
- full data-driven `mb_test` / `test_list`
- `mb_test1 /var/tmp/mabain_test 1800`, including periodic resource collection and reopen checks
- `mb_test2 /var/tmp/mabain_test 3600`, completing the full 60-minute resource-collection soak
- coordinated four-process `mb_test_mp` scenario: all three producers and the writer exited 0
- `hashmap_lookup_bench 1000000 5000000 /var/tmp/mabain_hashmap_bench 256 0.5 1`: 5,000,000/5,000,000 hits at 201.196 ns per lookup
- `git diff --check`

Not run on shared Vasco:

- privileged/destructive filesystem tests remain safety-gated by the runbook because they mount loop filesystems or deliberately fill `/tmp` to 100%

## Validation note

The first `mb_test` attempt exposed an existing legacy test-cleanup issue: deleting the database header without deleting its matching `/dev/shm/_mabain_q<inode>` file can reuse a stale queue after inode reuse. After removing only that unused test queue, the complete `mb_test` rerun passed. This is separate from the prefix-cache changes.
